### PR TITLE
centos-ci: add pynfs test job

### DIFF
--- a/pynfs/client.sh
+++ b/pynfs/client.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# Prepare a NFS-client for pynfs testing
+# - install needed tools and libs
+# - checkout pynfs from git
+# - build pynfs
+# - run the NFSv4.0 tests
+#
+
+EXPORT=pynfs
+
+# bail out if there is an error
+set -e
+
+# enable some debugging
+set -x
+
+# variables we expect
+[ -n "${NFS_SERVER}" ]
+[ -n "${EXPORT}" ]
+
+yum -y install git gcc nfs-utils redhat-rpm-config python-devel krb5-devel
+
+#install pynfs test suite
+git clone git://linux-nfs.org/~bfields/pynfs.git
+cd pynfs
+yes  | python setup.py build
+cd nfs4.0
+./testserver.py \
+	${NFS_SERVER}:/${EXPORT} \
+	--verbose \
+	--maketree \
+	--showomit \
+	--rundeps all
+
+# implicit exit status from ./testserver.py

--- a/pynfs/jenkins-job.py
+++ b/pynfs/jenkins-job.py
@@ -1,0 +1,55 @@
+#
+# from: https://raw.githubusercontent.com/kbsingh/centos-ci-scripts/master/build_python_script.py
+#
+# This script uses the Duffy node management api to get fresh machines to run
+# your CI tests on. Once allocated you will be able to ssh into that machine
+# as the root user and setup the environ
+#
+# XXX: You need to add your own api key below, and also set the right cmd= line 
+#      needed to run the tests
+#
+# Please note, this is a basic script, there is no error handling and there are
+# no real tests for any exceptions. Patches welcome!
+
+import json, urllib, subprocess, sys, os
+
+url_base="http://admin.ci.centos.org:8080"
+# we just build on CentOS-7/x86_64, CentOS-6 does not have 'mock'?
+ver=os.getenv("CENTOS_VERSION")
+arch=os.getenv("CENTOS_ARCH")
+count=2
+server_script_url=os.getenv("SERVER_TEST_SCRIPT")
+client_script_url=os.getenv("CLIENT_TEST_SCRIPT")
+
+# read the API key for Duffy from the ~/duffy.key file
+fo=open("/home/nfs-ganesha/duffy.key")
+api=fo.read().strip()
+fo.close()
+
+# build the URL to request the system(s)
+get_nodes_url="%s/Node/get?key=%s&ver=%s&arch=%s&count=%s" % (url_base,api,ver,arch,count)
+
+# request the system
+dat=urllib.urlopen(get_nodes_url).read()
+b=json.loads(dat)
+
+cmd="""ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@%s '
+	yum -y install curl &&
+	curl -o build.sh %s &&
+	bash build.sh'
+""" % (b['hosts'][0], server_script_url)
+rtn_code=subprocess.call(cmd, shell=True)
+
+if rtn_code == 0:
+    cmd="""ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@%s '
+        yum -y install curl &&
+        curl -o build.sh %s &&
+        NFS_SERVER="%s" bash build.sh'
+    """ % (b['hosts'][1], client_script_url, b['hosts'][0])
+    rtn_code=subprocess.call(cmd, shell=True)
+
+# return the system(s) to duffy
+done_nodes_url="%s/Node/done?key=%s&ssid=%s" % (url_base, api, b['ssid'])
+das=urllib.urlopen(done_nodes_url).read()
+
+sys.exit(rtn_code)

--- a/pynfs/nfs-ganesha_pynfs-gluster.xml
+++ b/pynfs/nfs-ganesha_pynfs-gluster.xml
@@ -1,0 +1,103 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description>Run pynfs (NFSv4.0) tests against the latest build of Ganesha with FSAL_GLUSTER.</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <jenkins.model.BuildDiscarderProperty>
+      <strategy class="hudson.tasks.LogRotator">
+        <daysToKeep>7</daysToKeep>
+        <numToKeep>7</numToKeep>
+        <artifactDaysToKeep>-1</artifactDaysToKeep>
+        <artifactNumToKeep>-1</artifactNumToKeep>
+      </strategy>
+    </jenkins.model.BuildDiscarderProperty>
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.17.1">
+      <projectUrl>http://git.linux-nfs.org/?p=bfields/pynfs.git;a=summary</projectUrl>
+      <displayName></displayName>
+    </com.coravy.hudson.plugins.github.GithubProjectProperty>
+    <com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty plugin="naginator@1.15">
+      <optOut>false</optOut>
+    </com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>DUFFY_SCRIPT</name>
+          <description>Python script that reserves a machine from Duffy and starts the ${TEST_SCRIPT}.</description>
+          <defaultValue>https://raw.githubusercontent.com/nfs-ganesha/ci-tests/centos-ci/pynfs/jenkins-job.py</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>SERVER_TEST_SCRIPT</name>
+          <description>Test script to execute on the reserved machine acting as a server.</description>
+          <defaultValue>https://raw.githubusercontent.com/nfs-ganesha/ci-tests/centos-ci/pynfs/server.sh</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>CLIENT_TEST_SCRIPT</name>
+          <description>Test script to execute on the reserved machine acting as a client.</description>
+          <defaultValue>https://raw.githubusercontent.com/nfs-ganesha/ci-tests/centos-ci/pynfs/client.sh</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>CENTOS_VERSION</name>
+          <description>CentOS version to run the tests on (server + client)</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>7</string>
+              <string>6</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>CENTOS_ARCH</name>
+          <description>CentOS architecture to run the tests on (server + client)</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>x86_64</string>
+              <string>i386</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <assignedNode>nfs-ganesha</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers>
+    <org.jenkinsci.plugins.urltrigger.URLTrigger plugin="urltrigger@0.40">
+      <spec># run every two hours
+H */2 * * *</spec>
+      <triggerLabel>nfs-ganesha</triggerLabel>
+      <entries>
+        <org.jenkinsci.plugins.urltrigger.URLTriggerEntry>
+          <url>http://artifacts.ci.centos.org/nfs-ganesha/nightly/next/7/x86_64/repodata/repomd.xml</url>
+          <proxyActivated>false</proxyActivated>
+          <checkStatus>false</checkStatus>
+          <statusCode>200</statusCode>
+          <timeout>300</timeout>
+          <checkETag>false</checkETag>
+          <checkLastModificationDate>true</checkLastModificationDate>
+          <inspectingContent>false</inspectingContent>
+          <contentTypes/>
+        </org.jenkinsci.plugins.urltrigger.URLTriggerEntry>
+      </entries>
+      <labelRestriction>true</labelRestriction>
+    </org.jenkinsci.plugins.urltrigger.URLTrigger>
+  </triggers>
+  <concurrentBuild>true</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>curl -o jenkins-job.py ${DUFFY_SCRIPT}
+python jenkins-job.py</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <buildWrappers>
+    <hudson.plugins.ws__cleanup.PreBuildCleanup plugin="ws-cleanup@0.28">
+      <deleteDirs>false</deleteDirs>
+      <cleanupParameter></cleanupParameter>
+      <externalDelete></externalDelete>
+    </hudson.plugins.ws__cleanup.PreBuildCleanup>
+  </buildWrappers>
+</project>

--- a/pynfs/server.sh
+++ b/pynfs/server.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+VOLUME=pynfs
+
+# abort if anything fails
+set -e
+
+# be a little bit more verbose
+set -x
+
+# enable repositories
+yum -y install centos-release-gluster yum-utils
+yum-config-manager --add-repo=http://artifacts.ci.centos.org/nfs-ganesha/nightly/libntirpc/libntirpc-latest.repo
+yum-config-manager --add-repo=http://artifacts.ci.centos.org/nfs-ganesha/nightly/nfs-ganesha-next.repo
+
+# install the latest version of gluster
+yum -y install nfs-ganesha nfs-ganesha-gluster glusterfs-ganesha
+
+# start nfs-ganesha service
+systemctl start rpcbind
+systemctl start nfs-ganesha
+
+# create and start gluster volume
+systemctl start glusterd
+mkdir -p /bricks
+gluster v create ${VOLUME} replica 2 $(hostname --fqdn):/bricks/b{1,2} force
+gluster v start ${VOLUME} force
+
+#disable gluster-nfs
+#gluster v set vol1 nfs.disable on
+#sleep 2
+
+#enable cache invalidation
+#gluster v set vol1 cache-invalidation on
+
+# TODO: open only the ports needed?
+# disable the firewall, otherwise the client can not connect
+systemctl stop firewalld || service iptables stop
+
+# TODO: SELinux prevents creating special files on Gluster bricks (bz#1331561)
+setenforce 0
+
+# Export the volume
+/usr/libexec/ganesha/create-export-ganesha.sh /etc/ganesha ${VOLUME}
+/usr/libexec/ganesha/dbus-send.sh /etc/ganesha on ${VOLUME}
+
+# wait till server comes out of grace period
+sleep 90


### PR DESCRIPTION
Reserves two machines, one for the server and one for the client. After
configuring the server, the tests are compiled and run on the client.

A new job will automatically start when the nightly NFS-Ganesha RPMs are
available. The test only uses CentOS-7/x86_64 by default.

Results in Jenkins are currently incorrect. The test-script in client.sh
always returns success when some tests were run. This needs to get
addressed in the uptream pynfs repository.

Suggested-by: Jiffin Tony Thottan jthottan@redhat.com
Signed-off-by: Niels de Vos ndevos@redhat.com
