### PR TITLE
Initial Jenkins job to trigger cthon04 on new patches

### DIFF
--- a/common-scripts/add-gerrit-comment.sh
+++ b/common-scripts/add-gerrit-comment.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+#
+# Report the previous test result to Gerrit
+#
+# This should be a 2nd stage part of a multijob configuration in Jenkins. The
+# result of the previous job is checked. Based upon the subject of the patch
+# (contains the word "WIP" or not), voting is done.
+#
+# WARNING: Currently this script does never set Verified=-1. This is done to
+# prevent incorrect negative voting. Change the part at the "TODO" for this.
+#
+# Environment variables used:
+#  - GERRIT_HOST
+#  - GERRIT_PORT
+#  - GERRIT_PROJECT
+#  - GERRIT_PATCHSET_REVISION: the git commit-id
+#  - GERRIT_CHANGE_SUBJECT: subject of the patch (WIP?)
+#  - LAST_TRIGGERED_JOB_NAME: like "nfs_ganesha_cthon04"
+#  - TRIGGERED_BUILD_RESULT_${LAST_TRIGGERED_JOB_NAME}: SUCCESS/FAILURE
+#  - TRIGGERED_BUILD_NUMBER_${LAST_TRIGGERED_JOB_NAME}: job number
+#
+
+# check the result of the previous job
+RESULT_VAR="TRIGGERED_BUILD_RESULT_${LAST_TRIGGERED_JOB_NAME}"
+RESULT="${!RESULT_VAR}"
+case "${RESULT}" in
+'SUCCESS')
+	RET=0
+	;;
+'FAILURE')
+	RET=1
+	;;
+*)
+	RET=2
+	;;
+esac
+
+# check if the patch subject contains the word "WIP"
+if grep -q -i -w "WIP" <<< "${GERRIT_CHANGE_SUBJECT}"
+then
+	# add +10 for WIP patches
+	RET=$[${RET} + 10]
+fi
+
+# the BUILD_URL is for this job, and not very useful in a review comment.
+JOB_NUMBER_VAR="TRIGGERED_BUILD_NUMBER_${!LAST_TRIGGERED_JOB_NAME}"
+JOB_OUTPUT="${JENKINS_URL}/job/${LAST_TRIGGERED_JOB_NAME}/${!JOB_NUMBER_VAR}/console"
+
+# we accept different return values
+# 0 - SUCCESS + VOTE
+# 1 - FAILED + VOTE
+# 10 - SUCCESS + REPORT ONLY (NO VOTE)
+# 11 - FAILED + REPORT ONLY (NO VOTE)
+
+case ${RET} in
+0)
+	MESSAGE="${JOB_OUTPUT} : SUCCESS"
+	VERIFIED='--verified +1'
+	NOTIFY='--notify NONE'
+	EXIT=0
+	;;
+1)
+	MESSAGE="${JOB_OUTPUT} : FAILED"
+	# TODO: Enable voting if tests are stable. Env parameter?
+	#VERIFIED='--verified -1'
+	VERIFIED=''
+	NOTIFY='--notify ALL'
+	EXIT=1
+	;;
+10)
+	MESSAGE="${JOB_OUTPUT} : SUCCESS (WIP, skipping vote)"
+	VERIFIED=''
+	NOTIFY='--notify NONE'
+	EXIT=0
+	;;
+11)
+	MESSAGE="${JOB_OUTPUT} : FAILED (WIP, skipping vote)"
+	VERIFIED=''
+	NOTIFY='--notify NONE'
+	EXIT=1
+	;;
+*)
+	MESSAGE="${JOB_OUTPUT} : unknown return value ${RET}"
+	VERIFIED=''
+	NOTIFY='--notify NONE'
+	EXIT=1
+	;;
+esac
+
+# show the message on the console, it helps users looking the output
+echo "${MESSAGE}"
+
+# Update Gerrit with the success/failure status
+if [ -n "${GERRIT_PATCHSET_REVISION}" ]
+then
+    ssh \
+        -l jenkins-glusterorg \
+        -i ~/.ssh/gerrithub@gluster.org \
+        -o StrictHostKeyChecking=no \
+        -p ${GERRIT_PORT} \
+        ${GERRIT_HOST} \
+        gerrit review \
+            --message "'${MESSAGE}'" \
+            --project ${GERRIT_PROJECT} \
+            ${VERIFIED} \
+            ${NOTIFY} \
+            ${GERRIT_PATCHSET_REVISION}
+fi
+
+# mark the job as success/fail depending on the previous job
+exit ${EXIT}

--- a/nfs-ganesha_trigger-cthon04-on-new-patch.xml
+++ b/nfs-ganesha_trigger-cthon04-on-new-patch.xml
@@ -1,0 +1,126 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<com.tikal.jenkins.plugins.multijob.MultiJobProject plugin="jenkins-multijob-plugin@1.21">
+  <actions/>
+  <description>Start cthon04 test when a new patch is posted to GerritHub.</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.19.1">
+      <projectUrl>https://github.com/nfs-ganesha/nfs-ganesha/</projectUrl>
+      <displayName></displayName>
+    </com.coravy.hudson.plugins.github.GithubProjectProperty>
+    <com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty plugin="naginator@1.17">
+      <optOut>true</optOut>
+    </com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>GERRITHUB_USER</name>
+          <description>User (bot) account to post results to GerritHub.</description>
+          <defaultValue>rdo-ci-centos</defaultValue>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <assignedNode>nfs-ganesha</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers>
+    <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger plugin="gerrit-trigger@2.20.0">
+      <spec></spec>
+      <gerritProjects>
+        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritProject>
+          <compareType>PLAIN</compareType>
+          <pattern>ffilz/nfs-ganesha</pattern>
+          <branches>
+            <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.Branch>
+              <compareType>ANT</compareType>
+              <pattern>**</pattern>
+            </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.Branch>
+          </branches>
+          <disableStrictForbiddenFileVerification>false</disableStrictForbiddenFileVerification>
+        </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritProject>
+      </gerritProjects>
+      <skipVote>
+        <onSuccessful>false</onSuccessful>
+        <onFailed>false</onFailed>
+        <onUnstable>false</onUnstable>
+        <onNotBuilt>false</onNotBuilt>
+      </skipVote>
+      <silentMode>true</silentMode>
+      <notificationLevel></notificationLevel>
+      <silentStartMode>false</silentStartMode>
+      <escapeQuotes>true</escapeQuotes>
+      <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
+      <dependencyJobsNames></dependencyJobsNames>
+      <commitMessageParameterMode>BASE64</commitMessageParameterMode>
+      <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
+      <buildStartMessage></buildStartMessage>
+      <buildFailureMessage></buildFailureMessage>
+      <buildSuccessfulMessage></buildSuccessfulMessage>
+      <buildUnstableMessage></buildUnstableMessage>
+      <buildNotBuiltMessage></buildNotBuiltMessage>
+      <buildUnsuccessfulFilepath></buildUnsuccessfulFilepath>
+      <customUrl></customUrl>
+      <serverName>nfs-ganesha-gerrithub</serverName>
+      <triggerOnEvents>
+        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginPatchsetCreatedEvent>
+          <excludeDrafts>true</excludeDrafts>
+          <excludeTrivialRebase>false</excludeTrivialRebase>
+          <excludeNoCodeChange>true</excludeNoCodeChange>
+        </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginPatchsetCreatedEvent>
+        <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedContainsEvent>
+          <commentAddedCommentContains>recheck cthon04</commentAddedCommentContains>
+        </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedContainsEvent>
+      </triggerOnEvents>
+      <dynamicTriggerConfiguration>false</dynamicTriggerConfiguration>
+      <triggerConfigURL></triggerConfigURL>
+      <triggerInformationAction/>
+    </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
+  </triggers>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.plugins.parameterizedtrigger.TriggerBuilder plugin="parameterized-trigger@2.30">
+      <configs>
+        <hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>CENTOS_VERSION=7
+CENTOS_ARCH=x86_64
+GERRIT_HOST=${GERRIT_HOST}
+GERRIT_PROJECT=${GERRIT_PROJECT}
+GERRIT_REFSPEC=${GERRIT_REFSPEC}</properties>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>nfs-ganesha_cthon04</projects>
+          <condition>ALWAYS</condition>
+          <triggerWithNoParameters>false</triggerWithNoParameters>
+          <block>
+            <buildStepFailureThreshold>
+              <name>FAILURE</name>
+              <ordinal>2</ordinal>
+              <color>RED</color>
+              <completeBuild>true</completeBuild>
+            </buildStepFailureThreshold>
+          </block>
+          <buildAllNodesWithLabel>false</buildAllNodesWithLabel>
+        </hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+      </configs>
+    </hudson.plugins.parameterizedtrigger.TriggerBuilder>
+    <hudson.tasks.Shell>
+      <command>curl https://raw.githubusercontent.com/nfs-ganesha/ci-tests/centos-ci/common-scripts/basic-gluster.sh | bash</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers>
+    <com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper plugin="ssh-agent@1.10">
+      <credentialIds>
+        <string>${GERRITHUB_USER}</string>
+      </credentialIds>
+      <ignoreMissing>false</ignoreMissing>
+    </com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>
+  </buildWrappers>
+  <pollSubjobs>false</pollSubjobs>
+</com.tikal.jenkins.plugins.multijob.MultiJobProject>


### PR DESCRIPTION
The new common-scripts/add-gerrit-comment.sh is based on teh script that
is part of the trigger-fsal_gluster job. It has been split out so that
triggers for other tests can use it too.

Signed-off-by: Niels de Vos ndevos@redhat.com
