### PR TITLE
Update CMake invocation for new goptions

### DIFF
--- a/build-fsal_gluster/build-fsal_gluster.sh
+++ b/build-fsal_gluster/build-fsal_gluster.sh
@@ -52,7 +52,7 @@ git submodule update --init || git submodule sync
 mkdir build
 cd build
 
-( cmake ../src -DCMAKE_BUILD_TYPE=Maintainer -DUSE_FSAL_RGW=ON && make rpm ) || touch FAILED
+( cmake ../src -DCMAKE_BUILD_TYPE=Maintainer -DUSE_FSAL_GLUSTER=ON -DUSE_FSAL_CEPH=ON -DUSE_FSAL_RGW=ON -DUSE_DBUS=ON -DUSE_ADMIN_TOOLS=ON && make rpm ) || touch FAILED
 
 # dont vote if the subject of the last change includes the word "WIP"
 if ( git log --oneline -1 | grep -q -i -w 'WIP' )

--- a/common-scripts/basic-gluster.sh
+++ b/common-scripts/basic-gluster.sh
@@ -84,7 +84,7 @@ else
 	mkdir build
 	pushd build
 
-	cmake -DCMAKE_BUILD_TYPE=Maintainer -DBUILD_CONFIG=everything ../src
+	cmake -DCMAKE_BUILD_TYPE=Maintainer -DUSE_FSAL_GLUSTER=ON ../src
 	make dist
 	rpmbuild -ta --define "_srcrpmdir $PWD" --define "_rpmdir $PWD" *.tar.gz
 	rpm_arch=$(rpm -E '%{_arch}')


### PR DESCRIPTION
CMake usage for options changed in Ganesha, so that it tracks default-on
verses explicitly enabled options, failing in the latter case when
dependencies are not present.

Change the CI builds as follows:

The main build CI now builds with an explicit request for GLUSTER, CEPH,
RGW, DBUS and so on.

The actual test runs only build with GLUSTER required, and the rest are
defaults.  This should allow build verification with minimal
interruption of testing.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>