### PR TITLE
Speed up dbench testing by installing RPMs and not building dbench from source

### DIFF
--- a/dbench/client.sh
+++ b/dbench/client.sh
@@ -33,12 +33,13 @@ curl -o ${WORKDIR}/client.txt https://raw.githubusercontent.com/sahlberg/dbench/
 # v3 mount
 mkdir -p /mnt/nfsv3
 mount -t nfs -o vers=3 ${SERVER}:${EXPORT} /mnt/nfsv3
+mkdir /mnt/nfsv3/v3
 
 # Running dbench suite on v3 mount
 echo "---------------------------------------"
 echo "dbench Test Running for v3 Mount..."
 echo "---------------------------------------"
-dbench --loadfile=${WORKDIR}/client.txt 2 > ${WORKDIR}/dbenchTestLog.txt
+dbench --directory=/mnt/nfsv3/v3 --loadfile=${WORKDIR}/client.txt 2 > ${WORKDIR}/dbenchTestLog.txt
 tail -1 ${WORKDIR}/dbenchTestLog.txt | grep "Throughput"
 status=$?
 if [ $status -eq 0 ]
@@ -56,12 +57,13 @@ umount -l /mnt/nfsv3
 # v4 mount
 mkdir -p /mnt/nfsv4
 mount -t nfs -o vers=4.0 ${SERVER}:${EXPORT} /mnt/nfsv4
+mkdir /mnt/nfsv4/v4
 
 # Running dbench suite on v4.0 mount
 echo "---------------------------------------"
 echo "dbench Test Running for v4.0 Mount..."
 echo "---------------------------------------"
-dbench --loadfile=${WORKDIR}/client.txt 2 > ${WORKDIR}/dbenchTestLog.txt
+dbench --directory=/mnt/nfsv4/v4 --loadfile=${WORKDIR}/client.txt 2 > ${WORKDIR}/dbenchTestLog.txt
 tail -1 ${WORKDIR}/dbenchTestLog.txt | grep "Throughput"
 status=$?
 if [ $status -eq 0 ]
@@ -79,12 +81,13 @@ umount -l /mnt/nfsv4
 # v4.1 mount
 mkdir -p /mnt/nfsv4_1
 mount -t nfs -o vers=4.1 ${SERVER}:${EXPORT} /mnt/nfsv4_1
+mkdir /mnt/nfsv4_1/v41
 
 # Running dbench suite on v4.1 mount
 echo "---------------------------------------"
 echo "dbench Test Running for v4.1 Mount..."
 echo "---------------------------------------"
-dbench --loadfile=${WORKDIR}/client.txt 2 > ${WORKDIR}/dbenchTestLog.txt
+dbench --directory=/mnt/nfsv4_1/v41 --loadfile=${WORKDIR}/client.txt 2 > ${WORKDIR}/dbenchTestLog.txt
 tail -1 ${WORKDIR}/dbenchTestLog.txt | grep "Throughput"
 status=$?
 if [ $status -eq 0 ]


### PR DESCRIPTION
There is no need to build dbench from source, RPMs are available.

While updating this test, I noticed that the dbench runs are on the local filesystem, and not on the NFS exports. The 2nd patch in this PR addresses that by creating a workdir for each test, and passing the `--directory` option to the `dbench` executable.