### PR TITLE
Install userspace-rcu-devel in other scripts

### DIFF
--- a/client-permissions/server.sh
+++ b/client-permissions/server.sh
@@ -74,7 +74,7 @@ then
 		yum -y --enablerepo=centos-gluster*-test install glusterfs-api-devel
 		yum -y install git bison flex cmake gcc-c++ libacl-devel krb5-devel \
 			dbus-devel libnfsidmap-devel libwbclient-devel libcap-devel \
-			libblkid-devel rpm-build redhat-rpm-config
+			libblkid-devel rpm-build redhat-rpm-config userspace-rcu-devel
 
 		git init "${GIT_REPO}"
 		pushd "${GIT_REPO}"

--- a/common-scripts/basic-gluster.sh
+++ b/common-scripts/basic-gluster.sh
@@ -70,7 +70,7 @@ else
 	yum -y --enablerepo=centos-gluster*-test install glusterfs-api-devel
 	yum -y install git bison flex cmake gcc-c++ libacl-devel krb5-devel \
 		dbus-devel libnfsidmap-devel libwbclient-devel libcap-devel \
-		libblkid-devel rpm-build redhat-rpm-config
+		libblkid-devel rpm-build redhat-rpm-config userspace-rcu-devel
 
 	git init "${GIT_REPO}"
 	pushd "${GIT_REPO}"


### PR DESCRIPTION
The last PR missed a couple of other places that should ensure the package is installed. It might be nice to consolidate these package lists one of these days (maybe an install-deps.sh script in the main ganesha tree?). In any case, fix this up for now.