### PR TITLE
Fix check - verification of jobs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Verify Jenkins jobs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3 
+      - uses: actions/checkout@v4
       - name: build JJB container image
         run: docker build -t nfs-ganesha-ci-tests -f tests/Containerfile .
       - name: update Jenkins Jobs

--- a/tests/verify-yaml.sh
+++ b/tests/verify-yaml.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-jenkins-jobs test jobs
+jenkins-jobs test globals/macro:jobs


### PR DESCRIPTION
The verification of jobs check is failing due to missing `macro` definition path. 

In this pull request, there are two changes
- Moving the `actions/checkout` to version `4` due to `Node.js 16 actions are deprecated.`
- Including the `macros` definition path along with the job definition for running `jenkins-jobs test`