### PR TITLE
[ScriptFix] Add submodule --recursive to build script

### DIFF
--- a/build_scripts/ganesha-build/build-ganesha.sh
+++ b/build_scripts/ganesha-build/build-ganesha.sh
@@ -44,6 +44,9 @@ fi
 git clone --depth=1 https://github.com/nfs-ganesha/nfs-ganesha.git
 pushd nfs-ganesha
 
+# update libntirpc
+git submodule update --recursive --init || git submodule sync
+
 # switch to the branch we want to build
 # git checkout ${GERRIT_BRANCH}
 #


### PR DESCRIPTION
   Problem:
  The ganesha-build job was failing [1] and the build process
  doesn't complete. The reason being prometheus-cpp-lite changed
  from being a submodule of ganesha to a submodule of ntirpc
  
  Solution:
  Update the script to add --recursive
  
  [1] https://jenkins-nfs-ganesha.apps.ocp.cloud.ci.centos.org/job/ganesha-build/38/console