### PR TITLE
Add clang-format check along with checkpatch.

### DIFF
--- a/build_scripts/checkpatch/.checkpatch.conf
+++ b/build_scripts/checkpatch/.checkpatch.conf
@@ -75,3 +75,45 @@
 # We have the FSF address in a lot of our headers at the moment,
 # should clean that up one day but ignoring for now.
 --ignore FSF_MAILING_ADDRESS
+
+# We will no longer get grumpy about single line braces
+--ignore BRACES
+
+# We use #if 0 to preserve possibly interesting code
+--ignore IF_0
+--ignore IF_1
+
+--ignore PREFER_DEFINED_ATTRIBUTE_MACRO
+--ignore STRLCPY
+--ignore DATE_TIME
+
+# @todo FSF work on removing these ones if they make sense...
+--ignore BLOCK_COMMENT_STYLE
+#--ignore GLOBAL_INITIALISERS
+#--ignore UNSPECIFIED_INT
+#--ignore LONG_LINE
+#--ignore SUSPECT_CODE_INDENT
+#--ignore CONSTANT_COMPARISON
+#--ignore LINE_SPACING
+#--ignore TYPECAST_INT_CONSTANT
+
+# allow split strings
+--ignore SPLIT_STRING
+
+# we like symbolic permissions
+--ignore SYMBOLIC_PERMS
+
+# we are ok with function prototypes without identifier names
+--ignore FUNCTION_ARGUMENTS
+
+--ignore CONST_STRUCT
+
+#retain 80 column max line length
+ --max-line-length=80
+
+# ignore some annoying things
+--ignore COMPLEX_MACRO
+--ignore MACRO_WITH_FLOW_CONTROL
+--ignore DATE_TIME
+--ignore POINTER_LOCATION
+--ignore SPACING

--- a/jobs/checkpatch.yml
+++ b/jobs/checkpatch.yml
@@ -1,7 +1,13 @@
 - job:
     name: checkpatch 
     node: cico-workspace
-    description: "Run checkpatch on nfs-ganesha. This job is triggered by sending a change to https://review.gerrithub.io/#/q/project:ffilz/nfs-ganesha for review\n\nNote: it is possible to retrigger a test for a change by including recheck checkpatch in a comment on GerritHub." 
+    description: >-
+      Run checkpatch and clang-format on nfs-ganesha. This job is triggered by
+      sending a change to
+      https://review.gerrithub.io/#/q/project:ffilz/nfs-ganesha for review.
+
+      Note: it is possible to retrigger a test for a change by including recheck
+      checkpatch in a comment on GerritHub.
     project-type: freestyle
     concurrent: true 
     allow-manual-triggers: false

--- a/jobs/scripts/checkpatch.sh
+++ b/jobs/scripts/checkpatch.sh
@@ -1,34 +1,96 @@
+#!/bin/bash
+
+# This script has the following workflow
+#   1. Checkout the patch reference
+#   2. Run clang format against the review.
+#   3. Execute checkpatch
 set -o pipefail 
 set -x
 
 if [[ -n "$GERRIT_REFSPEC" ]]; then
-  GERRIT_REF="$GERRIT_REFSPEC"
-  REVISION="$GERRIT_PATCHSET_REVISION"
-  GERRIT_PUBLISH=true
+    GERRIT_REF="$GERRIT_REFSPEC"
+    REVISION="$GERRIT_PATCHSET_REVISION"
+    GERRIT_PUBLISH=true
 fi
 
-if ! [ -d nfs-ganesha ]; then
-  GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i $GERRITHUB_KEY" git clone --depth=1 -o gerrit ssh://$GERRIT_USER@review.gerrithub.io:29418/ffilz/nfs-ganesha.git -v
+if [ ! -d nfs-ganesha ]; then
+    GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i $GERRITHUB_KEY" git \
+        clone --depth=1 \
+        -o gerrit \
+        ssh://$GERRIT_USER@review.gerrithub.io:29418/ffilz/nfs-ganesha.git -v
 fi
 
 ( cd nfs-ganesha && git fetch gerrit $GERRIT_REF && git checkout $REVISION )
 
+job_url="${JENKINS_URL}/job/checkpatch/${BUILD_NUMBER}/console"
+
+# Install git-clang-format
+sudo dnf -qy git-clang-format
+
+pushd nfs-ganesha
+git clang-format -v \
+    --diff \
+    --style file:src/.clang-format \
+    --extensions c,cc,cpp,h,hpp \
+    HEAD~1
+RETURN_VALUE=$?
+popd
+
+# Post message
+case ${RETURN_VALUE} in
+    0)
+        MESSAGE="${job_url}: Success."
+        VERIFIED="--verified +1"
+        NOTIFY="--notify NONE"
+        EXIT=0
+        ;;
+    1)
+        MESSAGE="${job_url}: Failed"
+        VERIFIED='--verified -1'
+        NOTIFY="--notify all"
+        EXIT=1
+        ;;
+    *)
+        MESSAGE="${job_url}: UNKNOWN"
+        VERIFIED=''
+        NOTIFY="--notify NONE"
+        EXIT=1
+        ;;
+esac
+
+if [ "${GERRIT_PUBLISH}" == "true" ]; then
+    ssh \
+        -l ${GERRIT_USER} \
+        -i ${GERRITHUB_KEY} \
+        -o StrictHostKeyChecking=no \
+        -p ${GERRIT_PORT} \
+        ${GERRIT_HOST} \
+        gerrit review \
+            --message "'${MESSAGE}'" \
+            --project ${GERRIT_PROJECT} \
+            ${VERIFIED} \
+            ${NOTIFY} \
+            ${GERRIT_PATCHSET_REVISION}
+else
+    echo "Clang format review is not posted"
+fi
+
 publish_checkpatch() {
-  local SSH_GERRIT="ssh -p 29418 -i $GERRITHUB_KEY $GERRIT_USER@review.gerrithub.io"
-  if [[ "$GERRIT_PUBLISH" == "true" ]]; then
-    tee /proc/$$/fd/1 | $SSH_GERRIT "gerrit review --json --project ffilz/nfs-ganesha $REVISION"
-  else
-    echo "Would have submit:"
-    echo -n "echo '"
-    cat
-    echo "' | $SSH_GERRIT \"gerrit review --json --project ffilz/nfs-ganesha $REVISION\""
+    local SSH_GERRIT="ssh -p 29418 -i $GERRITHUB_KEY $GERRIT_USER@review.gerrithub.io"
+
+    if [[ "$GERRIT_PUBLISH" == "true" ]]; then
+        tee /proc/$$/fd/1 | \
+        $SSH_GERRIT "gerrit review --json --project ffilz/nfs-ganesha $REVISION"
+    else
+        echo "Would have submit:"
+        echo -n "echo '"
+        cat
+        echo "' | $SSH_GERRIT \"gerrit review --json --project ffilz/nfs-ganesha $REVISION\""
   fi 
 }
 
 # cd to ~/checkpatch for checkpatch.pl as a hack to get config without modifying $HOME
-GIT_DIR=nfs-ganesha/.git git show --format=email      | \
-  ( cd $WORKSPACE/ci-tests/build_scripts/checkpatch && ./checkpatch.pl -q - || true ) | \
-  python $WORKSPACE/ci-tests/build_scripts/checkpatch/checkpatch-to-gerrit-json.py    | \
-  publish_checkpatch
-
-
+GIT_DIR=nfs-ganesha/.git git show --format=email  | \
+    (cd $WORKSPACE/ci-tests/build_scripts/checkpatch && ./checkpatch.pl -q - || true ) | \
+    python $WORKSPACE/ci-tests/build_scripts/checkpatch/checkpatch-to-gerrit-json.py    | \
+    publish_checkpatch


### PR DESCRIPTION
The checkpatch job is updated to include clang-format check. We would be posting another message to the review with the status of the check.

The clang-format is run using `git clang-format HEAD~1`. On the node, we would be instaling `git-clang-format` to enable the check.