### PR TITLE
Fix package dependency issue observed during cthon04 tests

### DIFF
--- a/build_scripts/common/basic-gluster.sh
+++ b/build_scripts/common/basic-gluster.sh
@@ -119,14 +119,14 @@ else
 		-DUSE_FSAL_CEPH=OFF \
 		-DUSE_FSAL_RGW=OFF \
 		-DUSE_DBUS=ON \
-		-DUSE_ADMIN_TOOLS=ON
+		-DMONITORING=ON
 
     # We have noticed issues with bcond_with missing for some variables
 	# unwind_enriched_bt
 	sed -i 's/^ unwind_enriched_bt$/%bcond_with unwind_enriched_bt/g' ../src/nfs-ganesha.spec
 
     # monitoring
-	sed -i 's/^ monitoring$/%bcond_with monitoring/g' ../src/nfs-ganesha.spec
+	sed -i 's/^ monitoring$/%bcond_without monitoring/g' ../src/nfs-ganesha.spec
 
 	make dist
 	rpmbuild -ta --define "_srcrpmdir $PWD" --define "_rpmdir $PWD" *.tar.gz


### PR DESCRIPTION
Monitoring needs to be enabled to resolve the below dependency issue observed during cthon04 job

Error:
 Problem 1: conflicting requests
  - nothing provides libntirpcmonitoring.so()(64bit) needed by libntirpc-6.3-dev.9.el9.x86_64 from @commandline

In this commit, we pass `-DUSE_MONITORING=ON` to cmake. We also need to ensure a relevant fix is made to spec file.