### PR TITLE
Install git package on the reserved node.

### DIFF
--- a/build_scripts/common/check-patch.sh
+++ b/build_scripts/common/check-patch.sh
@@ -22,6 +22,9 @@ GERRIT_HOST=${GERRIT_HOST:-"review.gerrithub.io"}
 GERRIT_PORT=${GERRIT_PORT:-"29418"}
 GERRIT_PROJECT=${GERRIT_PROJECT:-"ffilz/nfs-ganesha"}
 
+# Install the required pre-requisites
+dnf -yq install git git-clang-format python3
+
 # Checkout the patch
 if [ ! -d nfs-ganesha ]; then
     git_project=$(basename "${GERRIT_PROJECT}")
@@ -31,9 +34,6 @@ if [ ! -d nfs-ganesha ]; then
     git fetch --depth=1 "${git_url}" "${GERRIT_REFSPEC}"
     popd
 fi
-
-# Install git-clang-format
-yum -y install git-clang-format
 
 pushd nfs-ganesha
 git checkout -b "${GERRIT_REFSPEC}" FETCH_HEAD
@@ -102,6 +102,6 @@ pushd nfs-ganesha/src/scripts
 # cd to ~/checkpatch for checkpatch.pl as a hack to get config without modifying $HOME
 GIT_DIR=~/nfs-ganesha/.git git show --format=email  | \
     ./checkpatch.pl -q - | \
-    python ~/checkpatch-to-gerrit-json.py | \
+    python3 ~/checkpatch-to-gerrit-json.py | \
     publish_checkpatch
 popd

--- a/jobs/scripts/checkpatch.sh
+++ b/jobs/scripts/checkpatch.sh
@@ -10,7 +10,7 @@ SERVER_IP=$(cat ${WORKSPACE}/hosts | sed -n '1p')
 
 # Copy checkpatch-to-gerrit-json file and check-patch
 scp ${SSH_OPTIONS} \
-    ${WORKSPACE}/ci-tests/build_scripts/common/checkpatch-to-gerrit-json.py \
+    ${WORKSPACE}/ci-tests/build_scripts/checkpatch/checkpatch-to-gerrit-json.py \
     root@${SERVER_IP}:checkpatch-to-gerrit-json.py
 scp ${SSH_OPTIONS} ${WORKSPACE}/ci-tests/build_scripts/common/check-patch.sh \
     root@${SERVER_IP}:check-patch.sh


### PR DESCRIPTION
The `checkpatch` job is failing due to missing `git` package. Recently, the task execution was moved from pod to a reserved node.

It was assumed that the node was hardened. In the commit, we are ensuring the git and python packages are installed. These are essential for executing the checks.