### PR TITLE
Switch to actively maintained pynfs repository

### DIFF
--- a/build_scripts/pynfs/client.sh
+++ b/build_scripts/pynfs/client.sh
@@ -16,7 +16,7 @@ set -x
 # install build and runtime dependencies
 dnf -y install git gcc nfs-utils redhat-rpm-config krb5-devel python3-devel python3-gssapi python3-ply
 
-rm -rf /root/pynfs && git clone git://linux-nfs.org/~bfields/pynfs.git
+rm -rf /root/pynfs && git clone git://git.linux-nfs.org/projects/cdmackay/pynfs.git
 
 cd /root/pynfs && yes | python3 setup.py build > /tmp/output_tempfile.txt
 echo $?

--- a/jobs/pynfs-acl.yml
+++ b/jobs/pynfs-acl.yml
@@ -12,7 +12,7 @@
     properties:
     - discarder
     - github:
-        url: http://git.linux-nfs.org/?p=bfields/pynfs.git;a=summary/
+        url: https://git.linux-nfs.org/?p=cdmackay/pynfs.git;a=summary
 
     parameters:
     - string:

--- a/jobs/pynfs-ceph.yml
+++ b/jobs/pynfs-ceph.yml
@@ -13,7 +13,7 @@
     properties:
     - discarder
     - github:
-        url: http://git.linux-nfs.org/?p=bfields/pynfs.git;a=summary/ 
+        url: https://git.linux-nfs.org/?p=cdmackay/pynfs.git;a=summary
 
     parameters:
     - string:

--- a/jobs/pynfs.yml
+++ b/jobs/pynfs.yml
@@ -12,7 +12,7 @@
     properties:
     - discarder
     - github:
-        url: http://git.linux-nfs.org/?p=bfields/pynfs.git;a=summary/ 
+        url: https://git.linux-nfs.org/?p=cdmackay/pynfs.git;a=summary
 
     parameters:
     - string:


### PR DESCRIPTION
In this pull request, the necessary changes to migrate to the actively maintained `pynfs` repository is implemented.