### PR TITLE
[CI-Job]: Add common GerritHub patchset trigger for basic checks and tests

### DIFF
--- a/build_scripts/common/basic-server-client.sh
+++ b/build_scripts/common/basic-server-client.sh
@@ -2,7 +2,7 @@
 
 function server_run()
 {
-  if [ "$JOB_NAME" == "iozone-vfs" ] || [ "$JOB_NAME" == "iozone-vfs-minmdcache" ]; then
+  if [ "$TEST_BACKEND" == "vfs" ]; then
     VOLUME_TYPE="VFS"
   elif [ "$JOB_NAME" == "storage-scale" ]; then
     VOLUME_TYPE="STORAGE_SCALE"
@@ -10,7 +10,7 @@ function server_run()
     VOLUME_TYPE="GLUSTER"
   fi
 
-  if [ "$JOB_NAME" == "pynfs-acl" ]; then
+  if [[ "$TEST_NAME" == pynfs-acl* ]]; then
     INCLUDE_ACL_PARAM=" ENABLE_ACL='${ENABLE_ACL}'"
   fi
 
@@ -31,7 +31,7 @@ function client_run()
 {
   scp ${SSH_OPTIONS} ${2} root@${1}:./$(basename ${2})
 
-  if [ "${JOB_NAME}" == "pynfs" ] || [ "${JOB_NAME}" == "pynfs-acl" ]; then
+  if [[ ${TEST_NAME} == pynfs* ]]; then
     INCLUDE_TEST_PARAMS="TEST_PARAMETERS='${TEST_PARAMETERS}'"
   fi
 
@@ -70,6 +70,8 @@ elif [ "${SERVER_TEST_SCRIPT}" ] && [ "${CLIENT_TEST_SCRIPT}" ]; then
     client_run ${CLIENT_IP} ${CLIENT_TEST_SCRIPT} ${SERVER_IP}
     FINAL_RESULT=$?
     echo "Client script status = $FINAL_RESULT"
+    # Copy failures.txt if it exists
+    scp root@${CLIENT_IP}:/root/failures.txt $WORKSPACE || true
   else
     scp root@${SERVER_IP}:/root/rpmbuild/BUILD/nfs-ganesha-5.4/CMakeFiles/CMakeOutput.log $WORKSPACE
     scp root@${SERVER_IP}:/root/rpmbuild/BUILD/nfs-ganesha-5.4/CMakeFiles/CMakeError.log $WORKSPACE

--- a/build_scripts/common/basic-vfs.sh
+++ b/build_scripts/common/basic-vfs.sh
@@ -92,7 +92,7 @@ else
 	mkdir build
 	pushd build
 
-	cmake -DCMAKE_BUILD_TYPE=Maintainer ../src
+	cmake ../src -DCMAKE_BUILD_TYPE=Maintainer -DUSE_FSAL_VFS=ON -DUSE_FSAL_GLUSTER=OFF -DUSE_FSAL_CEPH=OFF -DUSE_FSAL_RGW=OFF -DUSE_FSAL_GPFS=OFF -DUSE_MONITORING=ON
 	make dist
 	rpmbuild -ta --define "_srcrpmdir $PWD" --define "_rpmdir $PWD" *.tar.gz
 	rpm_arch=$(rpm -E '%{_arch}')

--- a/build_scripts/common/get-node.sh
+++ b/build_scripts/common/get-node.sh
@@ -31,6 +31,12 @@ else
     node_count=2
 fi
 
+if [ -n "$NODE_COUNT" ]; then
+  echo "NODE_COUNT is overridden since user defined NODE_COUNT env variable"
+  node_count=$NODE_COUNT
+  echo "New node_count is: $node_count"
+fi
+
 retry=0
 
 while [ $retry == 0 ]; do
@@ -44,6 +50,8 @@ while [ $retry == 0 ]; do
                 echo "${SESSION}" | jq -r '.session.nodes[].ipaddr' > "${WORKSPACE}"/hosts
                 echo "${SESSION}" | jq -r '.session.id' > "${WORKSPACE}"/session_id
                 retry=1
+                echo "Session ID: $(cat "${WORKSPACE}"/session_id)"
+                echo "Node reserved successfully!"
                 break
             else
                 echo -e "Failed to reserve node for the following reasons!\n-------------------------------------------------\n${CHECK_ERR}"

--- a/build_scripts/pynfs/client.sh
+++ b/build_scripts/pynfs/client.sh
@@ -37,21 +37,32 @@ RETURN_CODE41=$?
 echo "pynfs 4.1 test output:"
 cat $LOG_FILE41
 
-if [ $RETURN_CODE40 == 0 ]; then
-    echo "All tests passed in pynfs 4.0 test suite"
+FAILURE_LOG="/root/failures.txt"
+> "$FAILURE_LOG"  # Clear file
+
+FAIL_FOUND=0
+
+# pynfs 4.0
+if grep -q ": FAILURE" "$LOG_FILE40"; then
+    {
+        echo "pynfs 4.0 test suite failures:"
+        echo "------------------------------"
+        grep ": FAILURE" "$LOG_FILE40"
+        echo
+    } >> "$FAILURE_LOG"
+    FAIL_FOUND=1
 fi
 
-if [ $RETURN_CODE41 == 0 ]; then
-    echo "All tests passed in pynfs 4.1 test suite"
+# pynfs 4.1
+if grep -q ": FAILURE" "$LOG_FILE41"; then
+    {
+        echo "pynfs 4.1 test suite failures:"
+        echo "------------------------------"
+        grep ": FAILURE" "$LOG_FILE41"
+        echo
+    } >> "$FAILURE_LOG"
+    FAIL_FOUND=1
 fi
+echo -e "$(<"$FAILURE_LOG")"
 
-if [ $RETURN_CODE40 != 0 ] || [ $RETURN_CODE40 != 0 ]; then
-    echo "pynfs 4.0 test suite failures:"
-    echo "--------------------------"
-    cat $LOG_FILE40 | grep FAILURE
-
-    echo "pynfs 4.1 test suite failures:"
-    echo "--------------------------"
-    cat $LOG_FILE41 | grep FAILURE
-    exit 1
-fi
+exit $FAIL_FOUND

--- a/ceph/basic-ceph-pynfs.sh
+++ b/ceph/basic-ceph-pynfs.sh
@@ -1,0 +1,186 @@
+#!/bin/sh
+
+# if any command fails, the script should exit
+set -e
+
+# enable some more output
+set -x
+
+# these variables need to be set
+[ -n "${GERRIT_HOST}" ]
+[ -n "${GERRIT_PROJECT}" ]
+[ -n "${GERRIT_REFSPEC}" ]
+
+# only use https for now
+GIT_REPO="https://${GERRIT_HOST}/${GERRIT_PROJECT}"
+
+# enable the Storage SIG Gluster and Ceph repositories
+dnf -y install centos-release-ceph epel-release
+
+BUILDREQUIRES="git bison cmake dbus-devel flex gcc-c++ krb5-devel libacl-devel libblkid-devel libcap-devel redhat-rpm-config rpm-build xfsprogs-devel lvm2"
+
+BUILDREQUIRES_EXTRA="libnsl2-devel libnfsidmap-devel libwbclient-devel userspace-rcu-devel"
+
+# basic packages to install
+case "${CENTOS_VERSION}" in
+    9s)
+       yum install -y ${BUILDREQUIRES}
+       yum install --enablerepo=crb -y ${BUILDREQUIRES_EXTRA}
+       yum install -y libcephfs-devel
+    ;;
+esac
+
+git init $(basename "${GERRIT_PROJECT}")
+cd $(basename "${GERRIT_PROJECT}")
+git remote add origin ${GIT_REPO}
+git fetch --depth=1 origin ${GERRIT_REFSPEC}
+git checkout FETCH_HEAD
+
+# update libntirpc
+git submodule update --recursive --init || git submodule sync
+
+# cleanup old build dir
+[ -d build ] && rm -rf build
+
+mkdir build
+cd build
+
+( cmake ../src -DCMAKE_BUILD_TYPE=Maintainer -DUSE_FSAL_GLUSTER=OFF -DUSE_FSAL_CEPH=ON -DUSE_FSAL_RGW=OFF -DUSE_DBUS=ON -DUSE_ADMIN_TOOLS=ON && make) || touch FAILED
+make install
+
+
+# If failure found during build, return the status and skip proceeding
+# to ceph configuration
+
+RET=0
+if [ -e FAILED ]
+then
+	exit ${RET}
+fi
+
+# Create a virtual disk file (for OSD storage):
+truncate -s 35G /tmp/ceph-disk.img
+losetup -f /tmp/ceph-disk.img  # Attaches as a loop device (e.g., /dev/loop0)
+
+pvcreate /dev/loop0
+vgcreate ceph-vg /dev/loop0
+lvcreate -L 10G -n osd1 ceph-vg
+lvcreate -L 10G -n osd2 ceph-vg
+lvcreate -L 10G -n osd3 ceph-vg
+
+# Install and configure ceph cluster
+dnf install -y cephadm
+cephadm add-repo --release squid
+dnf install -y ceph
+cephadm bootstrap --mon-ip $(hostname -I | awk '{print $1}') --single-host-defaults --allow-fqdn-hostname
+ceph auth get client.bootstrap-osd -o /var/lib/ceph/bootstrap-osd/ceph.keyring
+
+# Attach the virtual disks
+ceph-volume lvm create --data /dev/ceph-vg/osd1
+ceph-volume lvm create --data /dev/ceph-vg/osd2
+ceph-volume lvm create --data /dev/ceph-vg/osd3
+
+# Verifying the disks
+lvdisplay
+lsblk
+ceph orch device ls
+
+# Now auto assign these lvms to the osd's
+ceph orch apply osd --all-available-devices
+
+# Wait for the osd's to be added
+
+echo "Waiting for at least one OSD to be ready..."
+TIMEOUT=300
+START_TIME=$(date +%s)
+while true; do
+    # Check if any OSD service exists and has at least one running OSD
+    OSD_STATUS=$(ceph orch ls --service-type osd --format json 2>/dev/null | \
+                 jq -r '.[0].status | select(.running != null) | .running >= 1')
+
+    # Check if the command succeeded and we got "true"
+    if [ "$OSD_STATUS" = "true" ]; then
+        echo "OSD is ready!"
+        break
+    fi
+
+    # Check timeout if set
+    if [ "$TIMEOUT" -gt 0 ]; then
+        CURRENT_TIME=$(date +%s)
+        ELAPSED=$((CURRENT_TIME - START_TIME))
+        if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+            echo "Timeout reached while waiting for OSD to be ready"
+            exit 1
+        fi
+    fi
+
+    sleep 5
+done
+
+# view the osd's
+ceph osd tree
+# Create a cephfs volume
+ceph fs volume create cephfs
+
+# Create subvolumegroup
+ceph fs subvolumegroup create cephfs ganeshagroup
+
+# Create subvolume
+ceph fs subvolume create cephfs nfs_subvol --group_name ganeshagroup --namespace-isolated
+
+# Get subvolume path
+CEPHFS_NAME="cephfs"
+SUBVOLUME_NAME="nfs_subvol"
+GROUP_NAME="ganeshagroup"
+SUBVOL_PATH=$(ceph fs subvolume getpath "$CEPHFS_NAME" "$SUBVOLUME_NAME" --group_name "$GROUP_NAME" 2>/dev/null)
+
+# Verify path was obtained
+if [ -z "$SUBVOL_PATH" ]; then
+    echo "ERROR: Failed to get subvolume path."
+    exit 1
+fi
+echo "Subvolume path: $SUBVOL_PATH"
+
+# create ganesha.conf file
+echo "NFS_CORE_PARAM {
+    Enable_NLM = false;
+    Enable_RQUOTA = false;
+    Protocols = 4;
+}
+
+EXPORT_DEFAULTS {
+    Access_Type = RW;
+}
+EXPORT {
+    Export_ID = 101;
+    Path = \"$SUBVOL_PATH\";
+    Pseudo = \"/nfs/cephfs\";
+    Protocols = 4;
+    Transports = TCP;
+    Access_Type = RW;
+    Squash = None;
+    FSAL {
+        Name = \"CEPH\";
+    }
+}" > /etc/ganesha/ganesha.conf
+
+# View the ganesha conf file
+cat /etc/ganesha/ganesha.conf
+
+mkdir -p /var/run/ganesha
+chmod 755 /var/run/ganesha
+chown root:root /var/run/ganesha
+
+# Creating backend recovery dir for nfs ganesha
+mkdir -p /var/lib/nfs/ganesha
+chmod 755 /var/lib/nfs/ganesha
+chown root:root /var/lib/nfs/ganesha
+
+ganesha.nfsd -f /etc/ganesha/ganesha.conf -L /var/log/ganesha.log
+if pgrep ganesha >/dev/null; then
+        echo "[OK] Service ganesha is running"
+        echo $(pgrep ganesha)
+    else
+        echo "[ERROR] Service ganesha is NOT running" >&2
+        exit 1
+fi

--- a/jobs/scripts/common.sh
+++ b/jobs/scripts/common.sh
@@ -20,48 +20,30 @@ fi
 bash $WORKSPACE/ci-tests/build_scripts/common/basic-server-client.sh
 RET=$?
 
-JOB_OUTPUT="${JENKINS_URL}/job/${LAST_TRIGGERED_JOB_NAME}/${BUILD_NUMBER}/console"
-
 case ${RET} in
 0)
-	MESSAGE="${JOB_OUTPUT} : SUCCESS"
-	VERIFIED='--verified +1'
-	NOTIFY='--notify NONE'
+	MESSAGE="**🟢 $TEST_NAME:** \`Passed\`"
 	EXIT=0
 	;;
 1)
-	MESSAGE="${JOB_OUTPUT} : FAILED"
-	# TODO: Enable voting if tests are stable. Env parameter?
-	#VERIFIED='--verified -1'
-	VERIFIED=''
-	NOTIFY='--notify ALL'
+	MESSAGE="**🔴 $TEST_NAME:** \`Failed\`"
 	EXIT=1
 	;;
 *)
-	MESSAGE="${JOB_OUTPUT} : unknown return value ${RET}"
-	VERIFIED=''
-	NOTIFY='--notify NONE'
+	MESSAGE="**🔴 $TEST_NAME:** \`unknown return value\` ${RET}"
 	EXIT=1
 	;;
 esac
 
-# show the message on the console, it helps users looking the output
-echo "${MESSAGE}"
-
-# Update Gerrit with the success/failure status
-if [ -n "${GERRIT_PATCHSET_REVISION}" ]; then
-    ssh \
-        -l jenkins-glusterorg \
-        -i $GERRITHUB_KEY \
-        -o StrictHostKeyChecking=no \
-        -p ${GERRIT_PORT} \
-        ${GERRIT_HOST} \
-        gerrit review \
-            --message "'${MESSAGE}'" \
-            --project ${GERRIT_PROJECT} \
-            ${VERIFIED} \
-            ${NOTIFY} \
-            ${GERRIT_PATCHSET_REVISION}
+# Append failures.txt content if it exists and is non-empty
+FAILURE_LOG=$WORKSPACE/failures.txt
+if [[ -s "$FAILURE_LOG" ]]; then
+    MESSAGE+="\n\`\`\`\n$(cat "$FAILURE_LOG")\n\`\`\`"
 fi
+
+# show the message on the console, it helps users looking the output
+echo -e "${MESSAGE}"
+
+echo -e "${MESSAGE}" >> result_message.txt
 
 exit ${EXIT}

--- a/jobs/scripts/fsal-build.sh
+++ b/jobs/scripts/fsal-build.sh
@@ -1,6 +1,6 @@
 # no need for verbose output
 set +x
-
+set -x
 # do not immediately fail on an error
 set +e
 
@@ -16,29 +16,29 @@ RET=$?
 
 case ${RET} in
 0)
-	MESSAGE="**🟢 $JOB_NAME:** \`SUCCESS\` - ${BUILD_URL}/console"
+	MESSAGE="**🟢 $JOB_NAME:** \`Passed\` - ${BUILD_URL}/console"
 	EXIT=0
 	;;
 1)
-	MESSAGE="**🔴 $JOB_NAME:** \`FAILED\` - ${BUILD_URL}/console"
+	MESSAGE="**🔴 $JOB_NAME:** \`Failed\` - ${BUILD_URL}/console"
 	EXIT=1
 	;;
 10)
-	MESSAGE="**🟢 $JOB_NAME:** \`SUCCESS - WIP\` - ${BUILD_URL}/console"
+	MESSAGE="**🟢 $JOB_NAME:** \`Passed - WIP\` - ${BUILD_URL}/console"
 	EXIT=0
 	;;
 11)
-	MESSAGE="**🔴 $JOB_NAME:** \`FAILED - WIP\` - ${BUILD_URL}/console"
+	MESSAGE="**🔴 $JOB_NAME:** \`Failed - WIP\` - ${BUILD_URL}/console"
 	EXIT=1
 	;;
 *)
-	MESSAGE="**🔴 $JOB_NAME:** \`FAILED : unknown return value ${RET}\` - ${BUILD_URL}/console"
+	MESSAGE="**🔴 $JOB_NAME:** \`Failed : unknown return value ${RET}\` - ${BUILD_URL}/console"
 	EXIT=1
 	;;
 esac
 
 echo "${MESSAGE}"
-echo "${MESSAGE}" > result_message.txt
+echo "${MESSAGE}" >> result_message.txt
 
 # exit with SUCCESS or FAIL only
 exit ${EXIT}

--- a/jobs/trigger-gerrit-patch-ci-run
+++ b/jobs/trigger-gerrit-patch-ci-run
@@ -1,0 +1,356 @@
+// Jenkinsfile for triggering jobs on new patches
+// This Jenkinsfile is designed to run various test jobs in parallel and clean up reserved nodes after execution.
+// It also summarizes the results of the jobs and posts them to Gerrit.
+
+// This function runs a test job with the provided environment variables and shell script.
+// It handles node reservation, result archiving, and node release.
+// The `envVars` parameter is a map of environment variables to be set for the job.
+// The `shellScript` parameter is the shell command to execute the test.
+// The `resultFile` parameter is optional and specifies the file to archive after the job completes
+def runTestJob = { envVars, shellScript, resultFile = null ->
+    stage(envVars.JOB_LABEL) {
+        try {
+            sh """
+                echo "Workspace: $WORKSPACE"
+                ls -la $WORKSPACE
+
+                echo "Exporting Env Variables"
+                ${envVars ? envVars.collect { k, v -> "export ${k}=\"${v}\"" }.join('\n') : ""}
+
+                echo "Getting available nodes..."
+                bash ./ci-tests/build_scripts/common/get-node.sh
+                cat ${WORKSPACE}/session_id > ${WORKSPACE}/session_id_${envVars.TEST_NAME}.txt
+
+                echo "[TEST]: ${envVars.JOB_LABEL}"
+                ${shellScript}
+            """
+        } finally {
+            if (resultFile) {
+                echo "Archiving results"
+                sh "mv -f result_message.txt ${resultFile} || echo 'No result_message.txt found to rename.'"
+                archiveArtifacts artifacts: resultFile, onlyIfSuccessful: false
+            }
+            sh """
+                SESSION_ID=\$(cat "${WORKSPACE}/session_id_${envVars.TEST_NAME}.txt")
+                duffy client retire-session "\${SESSION_ID}" > /dev/null
+                echo "Node released successfully!"
+            """
+        }
+    }
+}
+
+// This function checks the latest patchset in Gerrit and ensures that the current patchset is the latest one.
+// If a newer patchset exists or if the current patchset is not mergeable, it posts a message to Gerrit and aborts the build.
+// The function constructs a message based on the checks and posts it to Gerrit.
+def preCheckGerritPatchset() {
+    withCredentials([file(credentialsId: 'GERRITHUB_PRIVATE_KEY', variable: 'GERRITHUB_KEY_FILE')]) {
+        // Get the latest patchset number from Gerrit
+        def latestPatchset = sh(
+            script: """
+                ssh -i \$GERRITHUB_KEY_FILE -l \$GERRIT_USER -o StrictHostKeyChecking=no -p \$GERRIT_PORT \$GERRIT_HOST \\
+                gerrit query --format=JSON --current-patch-set change:\$GERRIT_CHANGE_ID | jq -r 'select(.currentPatchSet) | .currentPatchSet.number'
+            """,
+            returnStdout: true
+        ).trim()
+
+        def mergeable = sh(
+            script: """
+                ssh -i \$GERRITHUB_KEY_FILE -l \$GERRIT_USER -o StrictHostKeyChecking=no -p \$GERRIT_PORT \$GERRIT_HOST \\
+                gerrit query --format=JSON "is:mergeable change: \$GERRIT_CHANGE_ID" | jq -r 'select(.type=="stats") | .rowCount'
+            """,
+            returnStdout: true
+        ).trim()
+
+        echo "Latest patchset: ${latestPatchset}, Mergeable: ${mergeable}"
+        echo "Current patchset: ${GERRIT_PATCHSET_NUMBER}"
+
+        // Build a consolidated message
+        def MESSAGE = ""
+
+        if (latestPatchset.toInteger() != GERRIT_PATCHSET_NUMBER.toInteger()) {
+            MESSAGE += "Aborting: A newer patchset (${latestPatchset}) exists"
+        }
+
+        if (mergeable == "0") {
+            MESSAGE += "Cannot merge this patchset — merge conflict exists"
+        }
+
+        if (MESSAGE) {
+            sh """
+                ssh -i ${GERRITHUB_KEY_FILE} -l ${GERRIT_USER} -o StrictHostKeyChecking=no -p ${GERRIT_PORT} ${GERRIT_HOST} \\
+                gerrit review \\
+                    --message "${MESSAGE}" \\
+                    --project ${GERRIT_PROJECT} \\
+                    ${GERRIT_PATCHSET_REVISION}
+            """
+            error(MESSAGE)
+        }
+    }
+}
+
+// This function summarizes the results of the test jobs and posts them to Gerrit.
+// It takes a list of file globs to find result files and a job label for the summary.
+// It constructs a message based on the results found in the files and posts it to Gerrit.
+// It checks the content of each result file to determine if the job passed or failed.
+// The final message is written to a file and posted to Gerrit with appropriate flags for notification and verification.
+// The `fileGlobs` parameter is a list of glob patterns to match result files.
+// The `jobLabel` parameter is a label for the job being summarized.
+def summarizeAndPostResults = { fileGlobs, jobLabel ->
+    def messages = []
+    messages << "**${jobLabel}:** ${env.BUILD_URL}console"
+
+    def resultFiles = []
+    fileGlobs.each { glob ->
+        resultFiles.addAll(findFiles(glob: glob))
+    }
+    def notifyFlag = '--notify NONE'
+    def verifiedFlag = ''
+
+    if (resultFiles.length == 0) {
+        messages << "_No result files found._"
+    } else {
+        for (file in resultFiles) {
+            def jobName = file.name.replace('result_', '').replace('.txt', '')
+            def content = readFile(file.path).trim()
+            echo "Content:\n${content}"
+            if (content.contains("Passed")) {
+                messages << "**🟢 ${jobName}:** `Passed`"
+                if (jobName == 'cthon') {
+                    verifiedFlag = '--verified +1'
+                }
+            } else {
+                notifyFlag = '--notify ALL'
+                // To append the failures to Gerrit
+                if (jobName == 'cthon' || jobName.startsWith('pynfs')) {
+                    messages << "**🔴 ${jobName}:** `Failed` - [View Failures](${env.BUILD_URL}artifact/${file.name})"
+                } else {
+                    messages << "**🔴 ${jobName}:** `Failed`"
+                }
+            }
+        }
+    }
+
+    def finalMessage = messages.join("\n")
+    writeFile file: 'gerrit_message.txt', text: finalMessage
+
+    echo "=== Final Gerrit Message ==="
+    echo finalMessage
+
+    withCredentials([file(credentialsId: 'GERRITHUB_PRIVATE_KEY', variable: 'GERRITHUB_KEY_FILE')]) {
+        sh """
+            ssh -i ${GERRITHUB_KEY_FILE} -l ${GERRIT_USER} -o StrictHostKeyChecking=no -p ${GERRIT_PORT} ${GERRIT_HOST} \\
+                gerrit review \\
+                ${notifyFlag} \\
+                ${verifiedFlag} \\
+                --message "'\$(cat gerrit_message.txt)'" \\
+                --project ${GERRIT_PROJECT} \\
+                ${GERRIT_PATCHSET_REVISION}
+        """
+    }
+}
+
+// Main pipeline definition
+pipeline {
+    agent {
+        label 'cico-workspace'
+    }
+
+    options {
+        disableConcurrentBuilds()
+        timestamps()
+    }
+
+    stages {
+        stage('Pre-Check Patchset - Initial') {
+            when {
+                expression { true }
+            }
+            steps {
+                script {
+                    preCheckGerritPatchset()
+                }
+            }
+        }
+
+        stage('Run Clang, Checkpatch and FSAL jobs (Parallel)') {
+            steps {
+                withCredentials([file(credentialsId: 'GERRITHUB_PRIVATE_KEY', variable: 'GERRITHUB_KEY_FILE')]) {
+                    script {
+                        env.GERRITHUB_KEY = GERRITHUB_KEY_FILE
+
+                        catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                            parallel failFast: false,
+
+                                'Checkpatch & Clang Job': {
+                                    runTestJob(
+                                        [
+                                            JOB_LABEL: "Checkpatch_Clang_Job",
+                                            NODE_COUNT: 1,
+                                            TEST_NAME: "checkpatch-clang"
+                                        ],
+                                        "bash ./ci-tests/jobs/scripts/checkpatch.sh"
+                                    )
+                                },
+
+                                'FSAL_CephFS Jobs': {
+                                    runTestJob(
+                                        [
+                                            JOB_LABEL: "FSAL_CephFS_Jobs",
+                                            NODE_COUNT: 1,
+                                            TEST_NAME: "fsal-cephfs",
+                                            TEST_SCRIPT: "${WORKSPACE}/ci-tests/build_scripts/build-fsal/build-fsal_cephfs.sh"
+                                        ],
+                                        "bash ./ci-tests/jobs/scripts/fsal-build.sh",
+                                        'result_fsal_cephfs.txt'
+                                    )                                    
+                                },
+
+                                'FSAL_VFS Jobs': {
+                                    runTestJob(
+                                        [
+                                            JOB_LABEL: "FSAL_VFS_Jobs",
+                                            NODE_COUNT: 1,
+                                            TEST_NAME: "fsal-vfs",
+                                            TEST_SCRIPT: "${WORKSPACE}/ci-tests/build_scripts/build-fsal/build-fsal_vfs.sh"                                                                         
+                                        ],
+                                        "bash ./ci-tests/jobs/scripts/fsal-build.sh",
+                                        'result_fsal_vfs.txt'
+                                    )
+                                },
+
+                                'FSAL_GPFS Jobs': {
+                                    runTestJob(
+                                        [
+                                            JOB_LABEL: "FSAL_GPFS_Jobs",
+                                            NODE_COUNT: 1,
+                                            TEST_NAME: "fsal-gpfs",
+                                            TEST_SCRIPT: "${WORKSPACE}/ci-tests/build_scripts/build-fsal/build-fsal_gpfs.sh"
+                                        ],
+                                        "bash ./ci-tests/jobs/scripts/fsal-build.sh",
+                                        'result_fsal_gpfs.txt'
+                                    )
+                                },
+
+                                'FSAL_RGW Jobs': {
+                                    runTestJob(
+                                        [
+                                            JOB_LABEL: "FSAL_RGW_Jobs",
+                                            NODE_COUNT: 1,
+                                            TEST_NAME: "fsal-rgw",
+                                            TEST_SCRIPT: "${WORKSPACE}/ci-tests/build_scripts/build-fsal/build-fsal_rgw.sh"
+                                        ],
+                                        "bash ./ci-tests/jobs/scripts/fsal-build.sh",
+                                        'result_fsal_rgw.txt'
+                                    )
+                                }
+                            
+                        }
+                    }
+                }
+            }
+        }
+
+        stage('Result summary of FSAL Jobs') {
+            when {
+                expression { true }
+            }
+            steps {
+                script {
+                    summarizeAndPostResults(['result_fsal*.txt'], "FSAL Results")
+                }
+            }
+        }
+
+        stage('Pre-Check Patchset - Intermediate') {
+            steps {
+                script {
+                    preCheckGerritPatchset()
+                }
+            }
+        }
+
+        stage('Run PyNFS and Cthon Tests (Parallel)') {
+            steps {
+                script {
+                    catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+
+                        parallel failFast: false,
+
+                            'PyNFS - Ceph': {
+                                runTestJob(
+                                    [
+                                        JOB_LABEL: "PyNFS_with_Ceph",
+                                        NODE_COUNT: 2,
+                                        TEST_NAME: "pynfs-ceph",
+                                        SERVER_TEST_SCRIPT: "${WORKSPACE}/ci-tests/ceph/basic-ceph-pynfs.sh",
+                                        CLIENT_TEST_SCRIPT: "${WORKSPACE}/ci-tests/build_scripts/pynfs/client.sh",
+                                        EXPORT: "nfs/cephfs"
+                                    ],
+                                    "bash ./ci-tests/jobs/scripts/common.sh",
+                                    'result_pynfs_ceph.txt'
+                                )
+                            },
+
+                            'PyNFS ACL - Gluster': {
+                                runTestJob(
+                                    [
+                                        JOB_LABEL: "PyNFS ACL - Gluster",
+                                        NODE_COUNT: 2,
+                                        TEST_NAME: "pynfs-acl-gluster",
+                                        TEST_BACKEND: "gluster",
+                                        SERVER_TEST_SCRIPT: "${WORKSPACE}/ci-tests/build_scripts/common/basic-gluster.sh",
+                                        CLIENT_TEST_SCRIPT: "${WORKSPACE}/ci-tests/build_scripts/pynfs/client.sh",
+                                        EXPORT: "pynfs",
+                                        ENABLE_ACL: "True"
+                                    ],
+                                    "bash ./ci-tests/jobs/scripts/common.sh",
+                                    'result_pynfs_acl_gluster.txt'
+                                )
+                            },
+
+                            'PyNFS ACL - VFS': {
+                                runTestJob(
+                                    [
+                                        JOB_LABEL: "PyNFS ACL - VFS",
+                                        NODE_COUNT: 2,
+                                        TEST_NAME: "pynfs-acl-vfs",
+                                        TEST_BACKEND: "vfs",
+                                        SERVER_TEST_SCRIPT: "${WORKSPACE}/ci-tests/build_scripts/common/basic-vfs.sh",
+                                        CLIENT_TEST_SCRIPT: "${WORKSPACE}/ci-tests/build_scripts/pynfs/client.sh",
+                                        EXPORT: "pynfs",
+                                        ENABLE_ACL: "True"
+                                    ],
+                                    "bash ./ci-tests/jobs/scripts/common.sh",
+                                    'result_pynfs_acl_vfs.txt'
+                                )
+                            },
+
+                            'Cthon - Ceph': {
+                                runTestJob(
+                                    [
+                                        JOB_LABEL: "Cthon - Ceph",
+                                        NODE_COUNT: 1,
+                                        TEST_NAME: "cthon-ceph",
+                                        TEST_SCRIPT: "${WORKSPACE}/ci-tests/ceph/basic-ceph-cthon.sh"
+                                    ],
+                                    "bash ./ci-tests/jobs/scripts/common.sh",
+                                    'result_cthon.txt'
+                                )
+                            }
+                    }
+                }
+            }
+        }
+
+        stage('Result summary of PyNFS + Cthon Jobs') {
+            when {
+                expression { true }
+            }
+            steps {
+                script {
+                    summarizeAndPostResults(['result_pynfs*.txt', 'result_cthon*.txt'], "PyNFS and Cthon Results")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Introduces a centralized CI pipeline that runs automatically for every new patchset created in GerritHub. The workflow gathers change metadata, checks for duplicate or conflicting runs, and executes a controlled sequence of validation stages.

Stages include:
 - Code quality checks (Checkpatch, Clang Check)
 - FSAL tests (CephFS, GPFS, VFS, RGW) in parallel
 - Functional tests (Cthon-Ceph, Pynfs variants (Cthon–Ceph, Pynfs–Ceph, Pynfs-acl + Gluster, Pynfs-acl + VFS)) in parallel
 - voting based on Cthon job result

Each stage posts consolidated results back to Gerrit, ensuring fast feedback and consistent quality gates across all changes. The job aborts early if a newer patchset is detected, avoiding wasted compute and outdated results.

Pass Log: https://jenkins-nfs-ganesha.apps.ocp.cloud.ci.centos.org/job/trigger-gerrit-patch-ci-run/73/

<img width="720" height="312" alt="image" src="https://github.com/user-attachments/assets/04c90457-e94f-49b5-aa8e-e234ca8c57be" />

Snip from Gerrit:

<img width="1647" height="260" alt="image" src="https://github.com/user-attachments/assets/8109e154-c368-4b55-8dd1-7e3dcba4e8b0" />
<img width="1650" height="148" alt="image" src="https://github.com/user-attachments/assets/0d1200bf-2aa8-43a2-bded-ed128c6e0d21" />

