### PR TITLE
Gatecheck CI: Trim gerrit comments when exceeds the limit

### DIFF
--- a/jobs/Jenkinsfile.gatecheck
+++ b/jobs/Jenkinsfile.gatecheck
@@ -12,7 +12,15 @@ def postToGerrit(messageFile, notifyFlag, verifiedFlag, postCheckpatchFailure=fa
                         echo -e "\\nFailure Logs: ${env.BUILD_URL}artifact/failures/ \\n" >> gerrit_message.txt
                     fi
 
-                    cat ${messageFile} >> gerrit_message.txt
+                    # Append message but trim to ~15KB max
+                    # head -c 15000 ensures Gerrits 16KB limit wont be exceeded
+                    head -c 15000 ${messageFile} >> gerrit_message.txt
+
+                    # Indicate truncation if trimmed
+                    if [ \$(wc -c <${messageFile}) -gt 15000 ]; then
+                        echo -e "\\n... (output truncated, see failure logs for details)\\n" >> gerrit_message.txt
+                    fi
+
                     echo -e "\\nJenkins Build URL: ${env.BUILD_URL}console\\n" >> gerrit_message.txt
 
                     msg=\$(cat gerrit_message.txt)
@@ -37,7 +45,15 @@ def postToGerrit(messageFile, notifyFlag, verifiedFlag, postCheckpatchFailure=fa
                         echo -e "\\nFailure Logs: ${env.BUILD_URL}artifact/failures/ \\n" >> gerrit_message.txt
                     fi
 
-                    cat ${messageFile} >> gerrit_message.txt
+                    # Append message but trim to ~15KB max
+                    # head -c 15000 ensures Gerrits 16KB limit wont be exceeded
+                    head -c 15000 ${messageFile} >> gerrit_message.txt
+
+                    # Indicate truncation if trimmed
+                    if [ \$(wc -c <${messageFile}) -gt 15000 ]; then
+                        echo -e "\\n... (output truncated, see failure logs for details)\\n" >> gerrit_message.txt
+                    fi
+
                     echo -e "\\nJenkins Build URL: ${env.BUILD_URL}console\\n" >> gerrit_message.txt
                     
                     ssh -i ${GERRITHUB_KEY_FILE} -l ${GERRIT_USER} -o StrictHostKeyChecking=no -p ${GERRIT_PORT} ${GERRIT_HOST} \\


### PR DESCRIPTION
Gerrit Gatecheck: Trim review comments to avoid size limit errors

Problem:
--------
When Jenkins posts consolidated results (e.g., clang-format, checkpatch)
as a Gerrit review comment, the message sometimes exceeds Gerrit’s
maximum allowed comment size of 16 KB. In such cases Gerrit rejects the
comment with:

    error: One or more comments were rejected in validation:
    Comment size exceeds limit (34313 > 16384)

This prevents Jenkins from reporting results back to Gerrit.

Solution:
---------
Introduce trimming logic before posting comments to Gerrit:

- Limit message size to ~15 KB using `head -c 15000`.
- Add a marker indicating truncation if the message was shortened:
  
      ... (output truncated, see full log at <Jenkins URL>)

- Always append the Jenkins console URL for reference.

With this change, reviewers see a concise summary in Gerrit while full
logs remain accessible in Jenkins.

Impact:
-------
- Prevents Gerrit comment rejection due to oversize messages.
- Ensures Jenkins always posts status, even with large diffs/logs.
- Reviewers get a clear link to full build logs for details.

Log:
----
https://jenkins-nfs-ganesha.apps.ocp.cloud.ci.centos.org/job/gatecheck-trigger-gerrithub/408/

Sample GerritHub Response:
----------------------------
https://review.gerrithub.io/c/ffilz/nfs-ganesha/+/1222624