### PR TITLE
Enhance check for Clang and Checkpatch runs

### DIFF
--- a/build_scripts/clang/clangformat_to_gerrit_json.py
+++ b/build_scripts/clang/clangformat_to_gerrit_json.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+import json
+
+def main(fp=sys.stdin):
+    """
+    Convert git clang-format --diff output into Gerrit-compatible JSON with clear messages.
+    Handles multiple files, all types of hunks, and exact line numbers.
+    """
+
+    comments = {}
+    current_file = None
+    old_line = None
+    new_line = None
+
+    # Regex patterns
+    hunk_re = re.compile(r"@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+    file_re = re.compile(r"\+\+\+ b/(.+)")
+
+    removed_lines = []
+    added_lines = []
+
+    for raw_line in fp:
+        line = raw_line.rstrip("\n")
+
+        # Detect new file
+        file_match = file_re.match(line)
+        if file_match:
+            # Flush pending hunks for previous file
+            if removed_lines or added_lines:
+                emit_hunk_comments(current_file, removed_lines, added_lines, comments)
+                removed_lines.clear()
+                added_lines.clear()
+
+            current_file = file_match.group(1)
+            old_line = None
+            new_line = None
+            continue
+
+        # Detect hunk start
+        hunk_match = hunk_re.match(line)
+        if hunk_match:
+            # Flush previous hunk
+            if removed_lines or added_lines:
+                emit_hunk_comments(current_file, removed_lines, added_lines, comments)
+                removed_lines.clear()
+                added_lines.clear()
+
+            old_line = int(hunk_match.group(1))
+            new_line = int(hunk_match.group(3))
+            continue
+
+        if current_file is None or old_line is None or new_line is None:
+            continue
+
+        # Removed line (from original file)
+        if line.startswith('-') and not line.startswith('---'):
+            removed_lines.append((old_line, line[1:]))
+            old_line += 1
+            continue
+
+        # Added line (in new file)
+        if line.startswith('+') and not line.startswith('+++'):
+            added_lines.append((new_line, line[1:]))
+            new_line += 1
+            continue
+
+        # Context line: advance both counters
+        if not line.startswith('@@'):
+            old_line += 1
+            new_line += 1
+
+    # Flush last pending hunk
+    if removed_lines or added_lines:
+        emit_hunk_comments(current_file, removed_lines, added_lines, comments)
+
+    # Output JSON
+    if comments:
+        output = {
+            'comments': comments,
+            'message': 'clang-format found style deviations'
+        }
+    else:
+        output = {
+            'message': 'clang-format OK',
+            'notify': 'NONE'
+        }
+
+    print(json.dumps(output, indent=2))
+
+
+def emit_hunk_comments(current_file, removed_lines, added_lines, comments):
+    """Emit a single comment per hunk with clear, reviewer-friendly messages."""
+    if not current_file:
+        return
+
+    msg_lines = []
+    line_no = None
+
+    # Modified lines (removed + added)
+    if removed_lines and added_lines:
+        line_no = added_lines[0][0]
+        msg_lines.append("clang-format expects formatting for these lines:")
+        for (_, r) in removed_lines:
+            if r.strip() == "":
+                msg_lines.append("    - Extra blank line to be removed")
+            else:
+                msg_lines.append(f"    - {r}")
+        msg_lines.append("→ to be replaced with:")
+        for (_, a) in added_lines:
+            if a.strip() == "":
+                msg_lines.append("    + Blank line to be added")
+            else:
+                msg_lines.append(f"    + {a}")
+
+    # Removed-only lines
+    elif removed_lines:
+        line_no = removed_lines[0][0]
+        msg_lines.append("clang-format expects to remove the following lines:")
+        for (_, r) in removed_lines:
+            if r.strip() == "":
+                msg_lines.append("    - Extra blank line to be removed")
+            else:
+                msg_lines.append(f"    - {r}")
+
+    # Added-only lines
+    elif added_lines:
+        line_no = added_lines[0][0]
+        msg_lines.append("clang-format expects to add the following lines:")
+        for (_, a) in added_lines:
+            if a.strip() == "":
+                msg_lines.append("    + Blank line to be added")
+            else:
+                msg_lines.append(f"    + {a}")
+
+    if msg_lines:
+        comments.setdefault(current_file, []).append({
+            'line': line_no,
+            'message': "\n".join(msg_lines),
+            'unresolved': True
+        })
+
+
+if __name__ == '__main__':
+    main()

--- a/jobs/Jenkinsfile.gatecheck
+++ b/jobs/Jenkinsfile.gatecheck
@@ -1,9 +1,9 @@
 // Common helper to post message to Gerrit
-def postToGerrit(messageFile, notifyFlag, verifiedFlag, postCheckpatchFailure=false, checkpatchJsonFile='') {
+def postToGerrit(messageFile, notifyFlag, verifiedFlag, postCheckpatchFailure=false, checkpatchJsonFile='', postClangFailure=false, clangJsonFile='') {
     if (fileExists(messageFile)) {
         withCredentials([file(credentialsId: 'GERRITHUB_PRIVATE_KEY', variable: 'GERRITHUB_KEY_FILE')]) {
-            if (postCheckpatchFailure)  {
-                // JSON inline comments mode
+            if (fileExists(messageFile)) {
+                // Start with a fresh message file
                 sh """
                     # Start with a fresh file
                     : > gerrit_message.txt
@@ -22,40 +22,60 @@ def postToGerrit(messageFile, notifyFlag, verifiedFlag, postCheckpatchFailure=fa
                     fi
 
                     echo -e "\\nJenkins Build URL: ${env.BUILD_URL}console\\n" >> gerrit_message.txt
-
+                """                
+            }
+            
+            if (postCheckpatchFailure || postClangFailure)  {
+                // JSON inline comments mode
+                sh """
                     msg=\$(cat gerrit_message.txt)
-                    jq --arg msg "\$msg" '.message = \$msg' ${checkpatchJsonFile} > review_payload.json
+                    
+                    if ${postCheckpatchFailure.toString()} && ! ${postClangFailure.toString()}; then
+                        jq --arg msg "\$msg" '.message = \$msg' ${checkpatchJsonFile} > review_payload.json
+                    elif ${postClangFailure.toString()} && ! ${postCheckpatchFailure.toString()}; then
+                        jq --arg msg "\$msg" '.message = \$msg' ${clangJsonFile} > review_payload.json
+                    else
+                        # Merge both JSONs if both are enabled
+                        jq -s --arg msg "\$msg" '
+                        # Start with an empty base object
+                        reduce .[] as \$item (
+                            {comments:{}};
+
+                            # Only process if "comments" exists and is an object
+                            if (\$item | type == "object") and (\$item.comments? | type == "object") then
+                            reduce (\$item.comments | to_entries[]) as \$entry (
+                                .;
+                                .comments[\$entry.key] = ((.comments[\$entry.key] // []) + (\$entry.value // []))
+                            )
+                            else
+                            .
+                            end
+                        )
+                        | .message = \$msg
+                        ' ${checkpatchJsonFile} ${clangJsonFile} > review_payload.json
+                    fi
 
                     cat review_payload.json
+
+                    # Capture the count of comments
+                    count=\$(jq '[.comments[] | length] | add' review_payload.json)
+                    echo "Comments count: \$count"
+
+                    # Set verified flag to -1 if count > 10
+                    if [ "\$count" -gt 10 ]; then
+                        jq '.labels.Verified = -1' review_payload.json > tmp.json && mv tmp.json review_payload.json
+                        cat review_payload.json
+                    fi
 
                     ssh -i ${GERRITHUB_KEY_FILE} -l ${GERRIT_USER} -o StrictHostKeyChecking=no -p ${GERRIT_PORT} ${GERRIT_HOST} \\
                         gerrit review \\
                         ${notifyFlag} \\
-                        ${verifiedFlag} \\
                         --json < review_payload.json \\
                         --project ${GERRIT_PROJECT} \\
                         ${GERRIT_PATCHSET_REVISION}
                 """
             } else {
                 sh """
-                    # Start with a fresh file
-                    : > gerrit_message.txt
-
-                    if grep -q "Failed" ${messageFile}; then
-                        echo -e "\\nFailure Logs: ${env.BUILD_URL}artifact/failures/ \\n" >> gerrit_message.txt
-                    fi
-
-                    # Append message but trim to ~15KB max
-                    # head -c 15000 ensures Gerrits 16KB limit wont be exceeded
-                    head -c 15000 ${messageFile} >> gerrit_message.txt
-
-                    # Indicate truncation if trimmed
-                    if [ \$(wc -c <${messageFile}) -gt 15000 ]; then
-                        echo -e "\\n... (output truncated, see failure logs for details)\\n" >> gerrit_message.txt
-                    fi
-
-                    echo -e "\\nJenkins Build URL: ${env.BUILD_URL}console\\n" >> gerrit_message.txt
-                    
                     ssh -i ${GERRITHUB_KEY_FILE} -l ${GERRIT_USER} -o StrictHostKeyChecking=no -p ${GERRIT_PORT} ${GERRIT_HOST} \\
                         gerrit review \\
                         ${notifyFlag} \\
@@ -178,7 +198,7 @@ pipeline {
                     script {
                         def filesToCat = [
                             "${WORKSPACE}/failures/checkpatch_logs.json",
-                            "${WORKSPACE}/failures/clang_logs.txt",
+                            "${WORKSPACE}/failures/clang_logs.json",
                             "${WORKSPACE}/summary_checkpatch_fsal.txt",
                             "${WORKSPACE}/summary_status.txt"
                         ]
@@ -193,8 +213,10 @@ pipeline {
                         def notifyFlag = '--notify NONE'
                         def verifiedFlag = ''
                         def postCheckpatchFailure = false
+                        def postClangFailure = false
                         def statusFile = "${WORKSPACE}/summary_status.txt"
                         def checkpatchJSONFile = "${WORKSPACE}/failures/checkpatch_logs.json"
+                        def clangJSONFile = "${WORKSPACE}/failures/clang_logs.json"
 
                         if (fileExists(statusFile)) {
                             def content = readFile(statusFile).trim()
@@ -208,18 +230,28 @@ pipeline {
                             echo "summary_status.txt not found, using default flags"
                         }
 
-                        // Check for Clang-format failures in the JSON file to post to gerrit as inline comments
+                        // Check for Clang-format & Checkpatch failures in the JSON file to post to gerrit as inline comments
                         if (fileExists(checkpatchJSONFile)) {
                             def checkpatch_content = readFile(checkpatchJSONFile).trim()
                             echo "Checkpatch JSON content: ${checkpatch_content}"
                             
                             if (!checkpatch_content.contains("Checkpatch OK")) {
                                 postCheckpatchFailure = true
-                                echo "Clang-format failure detected → setting postCheckpatchFailure=${postCheckpatchFailure}"
+                                echo "Checkpatch failure detected → setting postCheckpatchFailure=${postCheckpatchFailure}"
                             }
                         }
  
-                        postToGerrit("${WORKSPACE}/summary_checkpatch_fsal.txt", notifyFlag, verifiedFlag, postCheckpatchFailure, "${WORKSPACE}/failures/checkpatch_logs.json")
+                         if (fileExists(clangJSONFile)) {
+                            def clang_content = readFile(clangJSONFile).trim()
+                            echo "Clang JSON content: ${clang_content}"
+                            
+                            if (!clang_content.contains("clang-format OK")) {
+                                postClangFailure = true
+                                echo "Clang-format failure detected → setting postClangFailure=${postClangFailure}"
+                            }
+                        }
+
+                        postToGerrit("${WORKSPACE}/summary_checkpatch_fsal.txt", notifyFlag, verifiedFlag, postCheckpatchFailure, "${WORKSPACE}/failures/checkpatch_logs.json", postClangFailure, "${WORKSPACE}/failures/clang_logs.json")
 
                         def failuresFolder = "${WORKSPACE}/failures"
                         def failuresFiles = findFiles(glob: 'failures/**')

--- a/tests/test_checkpatch_fsal.py
+++ b/tests/test_checkpatch_fsal.py
@@ -98,17 +98,40 @@ def test_checkpatch(create_session, server_node):
     logger.info("Checkpatch command: %s", cmd)
     out, _ = run_cmd(remote_session, cmd, check=False)
 
-    code = 0 if "Checkpatch OK" in out else 1
+    # Exclusions for files that don't impact code quality
+    exclusions = ["/COMMIT_MSG"]
+
+    code = 1 
+    # Condition 1: "Checkpatch OK" found
+    if "Checkpatch OK" in out:
+        code = 0
+    else:
+        try:
+            data = json.loads(out)
+        except json.JSONDecodeError:
+            logger.error("Failed to parse checkpatch output as JSON")
+            data = None
+
+        if data and "comments" in data:
+            comments = data["comments"]
+
+            # Remove all keys present in exclusions
+            for exc in exclusions:
+                comments.pop(exc, None)
+
+            logger.info("Comments after exclusions: %s", comments)
+            # Condition 2: If comments is empty after exclusions → success
+            if not comments:
+                code = 0
 
     if code != 0:
         checkpatch_log_file = os.path.join(FAILURE_FILE, "checkpatch_logs.json")
         with open(checkpatch_log_file, "w", encoding="utf-8") as f:
-            f.write(out)
+            f.write(json.dumps(data, indent=2))
         logger.info("Checkpatch logs written to %s", checkpatch_log_file)
 
         # Try to parse JSON output for cleaner logging to gerrit
         try:
-            data = json.loads(out)
             formatted_out = []
             for file, issues in data.get("comments", {}).items():
                 for issue in issues:
@@ -128,28 +151,65 @@ def test_checkpatch(create_session, server_node):
 # TEST 2: Clang format validation
 # Required Node: 1
 # -----------------------
-def test_clang_format(create_session):
+def test_clang_format(create_session, server_node):
     logger.info("[TEST] Running Clang format test")
     remote_session, test_workspace = create_session 
     
     logger.info("TEST WORKSPACE: %s", test_workspace)
+    files_to_copy = [
+        f"{WORKSPACE}/ci-tests/build_scripts/clang/clangformat_to_gerrit_json.py"
+    ]
+    scp_copy(server_node, files_to_copy, remote_dir=test_workspace)
 
-    out, code = run_cmd(
+    out, _ = run_cmd(
         remote_session,
         f"cd {test_workspace}/nfs-ganesha && "
         "git clang-format -v "
         "--diff "
         "--style file:src/.clang-format "
         "--extensions c,cc,cpp,h,hpp "
-        "HEAD~1", check=False
+        "HEAD~1 "
+        f"| python3 {test_workspace}/clangformat_to_gerrit_json.py", check=False
     )
+    
+    code = 0 if "clang-format OK" in out else 1
 
-    gerrit_custom_message(code, "Clang-format Check", out)
-    if code:
-        clang_log_file = os.path.join(FAILURE_FILE, "clang_logs.txt")
+    if code != 0:
+        clang_log_file = os.path.join(FAILURE_FILE, "clang_logs.json")
         with open(clang_log_file, "w", encoding="utf-8") as f:
             f.write(out)
-        logger.info("Clang format logs written to %s", clang_log_file)
+        logger.info("Clang logs written to %s", clang_log_file)
+
+
+        clang_dump = os.path.join(FAILURE_FILE, "clang_logs.txt")
+        dump_out, _ = run_cmd(
+            remote_session,
+            f"cd {test_workspace}/nfs-ganesha && "
+            "git clang-format -v "
+            "--diff "
+            "--style file:src/.clang-format "
+            "--extensions c,cc,cpp,h,hpp "
+            "HEAD~1", check=False
+        )
+        with open(clang_dump, "w", encoding="utf-8") as f:
+            f.write(dump_out)
+        logger.info("Clang format logs written to %s", clang_dump)
+
+        # Try to parse JSON output for cleaner logging to gerrit
+        try:
+            data = json.loads(out)
+            formatted_out = []
+            for file, issues in data.get("comments", {}).items():
+                for issue in issues:
+                    # Flatten message to avoid newlines/special chars
+                    msg = issue["message"].splitlines()[0]
+                    formatted_out.append(f"{file}:{issue['line']}: {msg}")
+            formatted_out.append(data.get("message", ""))
+            out = "\n".join(formatted_out)
+        except Exception:
+            logger.warning("Failed to parse clang output as JSON, using raw output")
+
+    gerrit_custom_message(code, "Clang-format Check", out)
 
     assert code == 0, f"Clang format check failed"
 


### PR DESCRIPTION
## Description
Enhance Gerrit review automation for Clang and Checkpatch checks
- Add inline unresolved comments for Clang check to highlight specific code issues
- Apply negative voting for Checkpatch/Clang failures when the number of issues exceeds 10
- Exclude known commit message warnings from Checkpatch to reduce noise

## Logs
- https://review.gerrithub.io/c/ffilz/nfs-ganesha/+/1224807/comments/5e5ce622_bd90f04b (For inline comments)
- https://review.gerrithub.io/c/ffilz/nfs-ganesha/+/1224807/comments/3f2b3d06_c848c6ca (That skips commit message warning)
- https://review.gerrithub.io/c/ffilz/nfs-ganesha/+/1219130/comments/ea28315a_ad0e9b4a (Successful run)