### PR TITLE
[Enhancement]: Introduce Custom cmake flags for Gatecheck jobs and Centralise

### DIFF
--- a/ci_utils/config/cmake_flags.yml
+++ b/ci_utils/config/cmake_flags.yml
@@ -1,0 +1,48 @@
+default:
+  - "-DCMAKE_BUILD_TYPE=Maintainer"
+  - "-DUSE_ADMIN_TOOLS=ON"
+  - "-DUSE_DBUS=ON"
+
+tests:
+  test_fsal_cephfs:
+    - "-DUSE_FSAL_GLUSTER=OFF"
+    - "-DUSE_FSAL_CEPH=ON" 
+    - "-DUSE_FSAL_RGW=OFF"
+    - "-DUSE_FSAL_GPFS=OFF"
+    - "-DUSE_FSAL_VFS=OFF"
+
+  test_fsal_rgw:
+    - "-DUSE_FSAL_GLUSTER=OFF" 
+    - "-DUSE_FSAL_CEPH=OFF"
+    - "-DUSE_FSAL_RGW=ON"
+    - "-DUSE_FSAL_GPFS=OFF"
+    - "-DUSE_FSAL_VFS=OFF"
+  
+  test_fsal_vfs:
+    - "-DUSE_FSAL_VFS=ON"
+    - "-DUSE_FSAL_GLUSTER=OFF"
+    - "-DUSE_FSAL_CEPH=OFF"
+    - "-DUSE_FSAL_RGW=OFF"
+    - "-DUSE_FSAL_GPFS=OFF"
+    - "-DUSE_MONITORING=ON"
+
+  test_fsal_gpfs:
+    - "-DUSE_FSAL_GLUSTER=OFF" 
+    - "-DUSE_FSAL_CEPH=OFF" 
+    - "-DUSE_FSAL_RGW=OFF"
+    - "-DUSE_FSAL_VFS=OFF"
+    - "-DUSE_GUI_ADMIN_TOOLS=OFF"
+    - "-D_MSPAC_SUPPORT=ON"
+    - "-DRADOS_URLS=OFF" 
+    - "-DUSE_RADOS_RECOV=OFF"
+    - "-DUSE_9P=OFF"
+    - "-DUSE_FSAL_NULL=OFF"
+    - "-DUSE_FSAL_XFS=OFF"
+    - "-DUSE_FSAL_MEM=OFF"
+    - "-DUSE_FSAL_LUSTRE=OFF"
+    - "-DUSE_FSAL_PROXY_V4=OFF"
+    - "-DUSE_FSAL_PROXY_V3=OFF"
+    - "-DUSE_FSAL_KVSFS=OFF"
+    - "-DUSE_FSAL_GPFS=ON"
+    - "-DMONITORING=ON"
+    - "-DUSE_MONITORING=ON"

--- a/ci_utils/nfs_ganesha/gpfs_ganesha_setup.py
+++ b/ci_utils/nfs_ganesha/gpfs_ganesha_setup.py
@@ -8,7 +8,7 @@ logger = get_logger(__name__)
 
 
 class GPFSGaneshaManager:
-    def __init__(self, session, export="/ibm/fs1", system_type="centos"):
+    def __init__(self, session, export="/ibm/fs1", system_type="centos", cmake_flags=None):
         """Handles GPFS and NFS-Ganesha installation and setup on a VM.
         Args:
             session (RemoteSession): Remote session to the VM.
@@ -16,6 +16,7 @@ class GPFSGaneshaManager:
         self.session = session
         self.export = export
         self.system_type = system_type
+        self.cmake_flags = cmake_flags
 
     # -------------------------------
     # Helpers
@@ -72,7 +73,7 @@ class GPFSGaneshaManager:
         logger.info("[STEP]: Building Ganesha from source...")
 
         BASE_PACKAGES="git bison flex cmake gcc-c++ libacl-devel krb5-devel dbus-devel rpm-build redhat-rpm-config gdb"
-        BUILDREQUIRES_EXTRA="libnsl2-devel libnfsidmap-devel libwbclient-devel userspace-rcu-devel libcephfs-devel"
+        BUILDREQUIRES_EXTRA="libnsl2-devel libnfsidmap-devel libwbclient-devel userspace-rcu-devel libcephfs-devel python3-devel"
     
         if self.system_type == "centos":
             repo_name = "crb"
@@ -100,9 +101,7 @@ class GPFSGaneshaManager:
         out, code = run_cmd(self.session, [
             f"bash -c 'cd {src_dir} && rm -rf {build_dir} && "
             f"mkdir -p {build_dir} && cd {build_dir} && "
-            f"{cmake_binary} {src_dir}/src -DCMAKE_BUILD_TYPE=Maintainer "
-            "-DUSE_FSAL_GPFS=ON -DUSE_DBUS=ON -D_MSPAC_SUPPORT=OFF "
-            "-DMONITORING=ON -DUSE_MONITORING=ON && make dist'"
+            f"{cmake_binary} {src_dir}/src {self.cmake_flags} && make dist'"
         ])
 
         logger.info("GPFS Make CephFS output: %s", out)
@@ -146,7 +145,13 @@ class GPFSGaneshaManager:
             logger.info("NTIRPC Version: %s", ntirpc_version)
             logger.info("NTIRPC RPM: %s", ntirpc_rpm)
 
-        run_cmd(self.session, f"bash -c 'cd {build_dir} && rpm -e gpfs.nfs-ganesha gpfs.nfs-ganesha-gpfs --nodeps'", check=False)
+        run_cmd(
+            self.session,
+            '\"bash -c \'rpm -e --nodeps \$(rpm -qa | grep \"^gpfs\\.nfs-ganesha\")\'\"',
+            check=False
+        )
+
+        run_cmd(self.session, f"\"bash -c 'rpm -qa | grep gpfs.nfs-ganesha'\"", check=False)
         out, _ = run_cmd(self.session, f"ls {build_dir}/x86_64/*.rpm")
         rpm_files_x86 = out.strip().splitlines()
 

--- a/ci_utils/nfs_ganesha/vfs_nfs_ganesha_setup.py
+++ b/ci_utils/nfs_ganesha/vfs_nfs_ganesha_setup.py
@@ -6,12 +6,13 @@ logger = get_logger(__name__)
 
 
 class VFSGaneshaManager:
-    def __init__(self, session):
+    def __init__(self, session, cmake_flags=None):
         """Handles VFS and NFS-Ganesha installation and setup on a VM.
         Args:
             session (RemoteSession): Remote session to the VM.
         """
         self.session = session
+        self.cmake_flags = cmake_flags
 
     # -------------------------------
     # Install Ganesha with VFS support
@@ -43,10 +44,7 @@ class VFSGaneshaManager:
             "rm -rf build && "
             "mkdir -p build && "
             "cd build && "
-            "cmake ../src -DCMAKE_BUILD_TYPE=Maintainer "
-            "-DUSE_FSAL_VFS=ON -DUSE_FSAL_GLUSTER=OFF "
-            "-DUSE_FSAL_CEPH=OFF -DUSE_FSAL_RGW=OFF "
-            "-DUSE_FSAL_GPFS=OFF -DUSE_MONITORING=ON && "
+            f"cmake ../src {self.cmake_flags} && "
             "make dist"
         )
 

--- a/ci_utils/requirements.txt
+++ b/ci_utils/requirements.txt
@@ -2,3 +2,4 @@ pytest==7.0.1
 pytest-xdist==3.0.2
 GitPython==3.1.18
 pytest-timeout==2.1.0
+pyyaml==6.0.1

--- a/tests/test_checkpatch_fsal.py
+++ b/tests/test_checkpatch_fsal.py
@@ -1,4 +1,7 @@
 import os
+import pathlib
+
+import yaml
 from ci_utils.common.remote_session import RemoteSession
 import pytest
 from ci_utils.common.logger import get_logger
@@ -26,6 +29,20 @@ def server_node():
     session_data = read_json_file(SESSION_FILE)
     return session_data.get("nodes")[0]
 
+@pytest.fixture(scope="session")
+def cmake_config():
+    # Find repo root based on THIS file's location
+    this_file = pathlib.Path(__file__).resolve()
+
+    # Navigate to ci_utils/config/cmake_flags.yml relative to this conftest
+    config_path = this_file.parent.parent / "ci_utils" / "config" / "cmake_flags.yml"
+
+    if not config_path.exists():
+        raise FileNotFoundError(f"CMake flag config not found: {config_path}")
+
+    with config_path.open() as f:
+        return yaml.safe_load(f)
+    
 # -----------------------
 # Fixtures - Test level
 # -----------------------
@@ -50,6 +67,26 @@ def create_session(server_node, request):
     yield session, default_dir  # Yield both session and default dir
     session.close()   
 
+@pytest.fixture
+def cmake_flags(request, cmake_config):
+    test_name = request.node.name
+    yaml_default = cmake_config.get("default", [])
+    yaml_test_specific = cmake_config.get("tests", {}).get(test_name, [])
+    logger.info(f"Getting default values: {os.environ}")
+
+    # ENV variable: general flags
+    env_flags = os.getenv("CMAKE_FLAGS", "")
+    env_flags_list = env_flags.split(",") if env_flags else []
+
+    # ENV override?
+    override = os.getenv("CMAKE_OVERRIDE", "").lower() in ("1", "true", "yes")
+
+    if override:
+        # Jenkins wants to ignore YAML entirely
+        return env_flags_list
+
+    # Merge YAML and CLI (YAML first, then CLI append / override)
+    return yaml_default + yaml_test_specific +  env_flags_list
 # ---------------------------------------------------------
 # Helper function to log results to summary file
 # ---------------------------------------------------------
@@ -219,10 +256,13 @@ def test_clang_format(create_session, server_node):
 # TEST 3: FSAL build tests - CephFS
 # Required Node: 1
 # -----------------------
-def test_fsal_cephfs(create_session):
+def test_fsal_cephfs(create_session, cmake_flags):
     logger.info("[TEST] Running FSAL CephFS test")
     remote_session, test_workspace = create_session
     logger.info("TEST WORKSPACE: %s", test_workspace)
+
+    flag_str = " ".join(cmake_flags)
+    logger.info("Using CMake flags: %s", flag_str)
 
     out, code = run_cmd(
         remote_session,
@@ -230,7 +270,7 @@ def test_fsal_cephfs(create_session):
         "rm -rf build && "
         "mkdir -p build && "
         "cd build && "
-        "cmake ../src -DCMAKE_BUILD_TYPE=Maintainer -DUSE_FSAL_GLUSTER=OFF -DUSE_FSAL_CEPH=ON -DUSE_FSAL_RGW=OFF -DUSE_DBUS=ON -DUSE_ADMIN_TOOLS=ON && "
+        f"cmake ../src {flag_str} && "
         "make", check=False
     )
 
@@ -248,10 +288,13 @@ def test_fsal_cephfs(create_session):
 # TEST 4: FSAL build tests - GPFS
 # Required Node: 1
 # -----------------------
-def test_fsal_gpfs(create_session):
+def test_fsal_gpfs(create_session, cmake_flags):
     logger.info("[TEST] Running FSAL GPFS test")
     remote_session, test_workspace = create_session
     logger.info("TEST WORKSPACE: %s", test_workspace)
+
+    flag_str = " ".join(cmake_flags)
+    logger.info("Using CMake flags: %s", flag_str)
 
     out, code = run_cmd(
         remote_session,
@@ -259,7 +302,7 @@ def test_fsal_gpfs(create_session):
         "rm -rf build && "
         "mkdir -p build && "
         "cd build && "
-        "cmake ../src -DCMAKE_BUILD_TYPE=Maintainer -DUSE_FSAL_GLUSTER=OFF -DUSE_FSAL_CEPH=OFF -DUSE_FSAL_RGW=OFF -DUSE_FSAL_GPFS=ON -DUSE_DBUS=ON -DUSE_ADMIN_TOOLS=ON && "
+        f"cmake ../src {flag_str} && "
         "make", check=False
     )
 
@@ -277,10 +320,13 @@ def test_fsal_gpfs(create_session):
 # TEST 5: FSAL build tests - RGW
 # Required Node: 1
 # -----------------------
-def test_fsal_rgw(create_session):
+def test_fsal_rgw(create_session, cmake_flags):
     logger.info("[TEST] Running FSAL RGW test")
     remote_session, test_workspace = create_session  # Unpack the tuple
     logger.info("TEST WORKSPACE: %s", test_workspace)
+
+    flag_str = " ".join(cmake_flags)
+    logger.info("Using CMake flags: %s", flag_str)
 
     out, code = run_cmd(
         remote_session,
@@ -288,7 +334,7 @@ def test_fsal_rgw(create_session):
         "rm -rf build && "
         "mkdir -p build && "
         "cd build && "
-        "cmake ../src -DCMAKE_BUILD_TYPE=Maintainer -DUSE_FSAL_GLUSTER=OFF -DUSE_FSAL_CEPH=OFF -DUSE_FSAL_RGW=ON -DUSE_DBUS=ON -DUSE_ADMIN_TOOLS=ON && "
+        f"cmake ../src {flag_str} && "
         "make", check=False
     )
 
@@ -306,10 +352,13 @@ def test_fsal_rgw(create_session):
 # TEST 6: FSAL build tests - VFS
 # Required Node: 1
 # -----------------------
-def test_fsal_vfs(create_session):
+def test_fsal_vfs(create_session, cmake_flags):
     logger.info("[TEST] Running FSAL VFS test")
     remote_session, test_workspace = create_session
     logger.info("TEST WORKSPACE: %s", test_workspace)
+
+    flag_str = " ".join(cmake_flags)
+    logger.info("Using CMake flags: %s", flag_str)
 
     out, code = run_cmd(
         remote_session,
@@ -317,7 +366,7 @@ def test_fsal_vfs(create_session):
         "rm -rf build && "
         "mkdir -p build && "
         "cd build && "
-        "cmake ../src -DCMAKE_BUILD_TYPE=Maintainer -DUSE_FSAL_VFS=ON -DUSE_FSAL_GLUSTER=OFF -DUSE_FSAL_CEPH=OFF -DUSE_FSAL_RGW=OFF -DUSE_FSAL_GPFS=OFF -DUSE_MONITORING=ON && "
+        f"cmake ../src {flag_str} && "
         "make", check=False
     )
 

--- a/tests/test_ci_pre_req.py
+++ b/tests/test_ci_pre_req.py
@@ -167,7 +167,7 @@ def setup_node_vfs(server_node):
     version = duffy_session.centos_version
 
     build_requires_vfs = "git bison flex cmake gcc-c++ libacl-devel krb5-devel dbus-devel rpm-build redhat-rpm-config gdb libblkid-devel libcap-devel libgfapi-devel xfsprogs-devel"
-    build_requires_extra_vfs= "libnsl2-devel libnfsidmap-devel libwbclient-devel userspace-rcu-devel libcephfs-devel"
+    build_requires_extra_vfs= "libnsl2-devel libnfsidmap-devel libwbclient-devel userspace-rcu-devel libcephfs-devel python3-devel"
     build_requires_add_on_vfs = "selinux-policy-devel sqlite"
 
     if version.startswith("9"):

--- a/tests/test_pynfs_cthon.py
+++ b/tests/test_pynfs_cthon.py
@@ -1,6 +1,9 @@
 import os
+import pathlib
 import re
 from time import sleep
+
+import yaml
 from ci_utils.ceph.ceph_setup import CephGaneshaSetup
 from ci_utils.common.remote_session import RemoteSession, RemoteSessionThroughJump
 from ci_utils.cthon.cthon_setup import CthonManager
@@ -49,6 +52,21 @@ def all_baremetal_nodes():
     with open(BAREMETAL_SESSION_FILE) as f:
         session_data = read_json_file(BAREMETAL_SESSION_FILE)
     return session_data.get("nodes", [])
+
+@pytest.fixture(scope="session")
+def cmake_config():
+    # Find repo root based on THIS file's location
+    this_file = pathlib.Path(__file__).resolve()
+
+    # Navigate to ci_utils/config/cmake_flags.yml relative to this conftest
+    config_path = this_file.parent.parent / "ci_utils" / "config" / "cmake_flags.yml"
+
+    if not config_path.exists():
+        raise FileNotFoundError(f"CMake flag config not found: {config_path}")
+
+    with config_path.open() as f:
+        return yaml.safe_load(f)
+    
 # -----------------------
 # Fixtures - Test level
 # -----------------------
@@ -90,6 +108,31 @@ def create_session(all_nodes, all_baremetal_nodes, request):
     for sess, _, _ in sessions:
         sess.close()
 
+@pytest.fixture
+def cmake_flags(request, cmake_config):
+    # Optional test-name override
+    forced_test_name = getattr(request, "param", None)
+
+    # Default behavior: real PyTest node name
+    test_name = forced_test_name or request.node.name
+
+    yaml_default = cmake_config.get("default", [])
+    yaml_test_specific = cmake_config.get("tests", {}).get(test_name, [])
+    logger.info(f"Getting default values: {os.environ}")
+
+    # ENV variable: general flags
+    env_flags = os.getenv("CMAKE_FLAGS", "")
+    env_flags_list = env_flags.split(",") if env_flags else []
+
+    # ENV override?
+    override = os.getenv("CMAKE_OVERRIDE", "").lower() in ("1", "true", "yes")
+
+    if override:
+        # Jenkins wants to ignore YAML entirely
+        return env_flags_list
+
+    # Merge YAML and CLI (YAML first, then CLI append / override)
+    return yaml_default + yaml_test_specific +  env_flags_list
 
 # -----------------------
 # Actual Tests Starts Here
@@ -100,8 +143,9 @@ def create_session(all_nodes, all_baremetal_nodes, request):
 # Node allocation: 1 (index 1)
 # -------------------------
 @pytest.mark.parametrize("create_session", [1], indirect=True)
+@pytest.mark.parametrize("cmake_flags", ["test_fsal_cephfs"], indirect=True)
 @pytest.mark.timeout(1200) 
-def test_cthon_cephfs(create_session):
+def test_cthon_cephfs(create_session, cmake_flags):
     try:
         logger.info("[TEST START]: Cthon with CephFS")
         
@@ -111,13 +155,16 @@ def test_cthon_cephfs(create_session):
         logger.info("[TEST WORKSPACE DETAILS]: Workspace: %s", test_workspace)
         logger.info("[TEST SESSION DETAILS]: Session: %s", remote_session)
 
+        flag_str = " ".join(cmake_flags)
+        logger.info("Using CMake flags: %s", flag_str)
+
         _, code = run_cmd(
             remote_session,
             f"cd {test_workspace}/nfs-ganesha && "
             "rm -rf build && "
             "mkdir -p build && "
             "cd build && "
-            "cmake ../src -DCMAKE_BUILD_TYPE=Maintainer -DUSE_FSAL_GLUSTER=OFF -DUSE_FSAL_CEPH=ON -DUSE_FSAL_RGW=OFF -DUSE_DBUS=ON -DUSE_ADMIN_TOOLS=ON && "
+            f"cmake ../src {flag_str} && "
             "make && "
             "make install"
         )
@@ -168,7 +215,8 @@ def test_cthon_cephfs(create_session):
 # Node allocation: 2 (index 0 - client, index 2 - server)
 # -----------------------------------------------------------------
 @pytest.mark.parametrize("create_session", [[0, 2]], indirect=True)
-def test_pynfs_cephfs(create_session):
+@pytest.mark.parametrize("cmake_flags", ["test_fsal_cephfs"], indirect=True)
+def test_pynfs_cephfs(create_session, cmake_flags):
     try:
         logger.info("[TEST START]: PyNFS with CephFS")
         (client_session, client_workspace, client_node), (server_session, server_workspace, server_node) = create_session
@@ -178,13 +226,16 @@ def test_pynfs_cephfs(create_session):
         logger.info("[TEST WORKSPACE DETAILS]: Client Workspace: %s, Server Workspace: %s", client_workspace, server_workspace)
         logger.info("[TEST SESSION DETAILS]: Client Session: %s, Server Session: %s", client_session, server_session)
 
+        flag_str = " ".join(cmake_flags)
+        logger.info("Using CMake flags: %s", flag_str)
+
         _, code = run_cmd(
             server_session,
             f"cd {server_workspace}/nfs-ganesha && "
             "rm -rf build && "
             "mkdir -p build && "
             "cd build && "
-            "cmake ../src -DCMAKE_BUILD_TYPE=Maintainer -DUSE_FSAL_GLUSTER=OFF -DUSE_FSAL_CEPH=ON -DUSE_FSAL_RGW=OFF -DUSE_DBUS=ON -DUSE_ADMIN_TOOLS=ON && "
+            f"cmake ../src {flag_str} && "
             "make && "
             "make install"
         )
@@ -241,7 +292,8 @@ def test_pynfs_cephfs(create_session):
 # Node allocation: 2 (index 0 - client, index 3 - server)
 # -------------------------------------------------------------------
 @pytest.mark.parametrize("create_session", [[0, 3]], indirect=True)
-def test_pynfs_acl_vfs(create_session):
+@pytest.mark.parametrize("cmake_flags", ["test_fsal_vfs"], indirect=True)
+def test_pynfs_acl_vfs(create_session, cmake_flags):
     try:
         logger.info("[TEST START]: PyNFS-ACL with VFS")
         (client_session, client_workspace, client_node), (server_session, server_workspace, server_node) = create_session
@@ -251,9 +303,13 @@ def test_pynfs_acl_vfs(create_session):
         logger.info("[TEST WORKSPACE DETAILS]: Client Workspace: %s, Server Workspace: %s", client_workspace, server_workspace)
         logger.info("[TEST SESSION DETAILS]: Client Session: %s, Server Session: %s", client_session, server_session)
 
+        flag_str = " ".join(cmake_flags)
+        logger.info("Using CMake flags: %s", flag_str)
+
         logger.info("NFS Ganesha setup for VFS tests")
         ganesha_setup = VFSGaneshaManager(
-            session=server_session
+            session=server_session,
+            cmake_flags=flag_str
         )
         ganesha_setup.install_ganesha(server_workspace)
         
@@ -297,7 +353,8 @@ def test_pynfs_acl_vfs(create_session):
 # -----------------------
 @pytest.mark.baremetal
 @pytest.mark.parametrize("create_session", [0], indirect=True)
-def test_pynfs_gpfs(create_session):
+@pytest.mark.parametrize("cmake_flags", ["test_fsal_gpfs"], indirect=True)
+def test_pynfs_gpfs(create_session, cmake_flags):
     try:
         logger.info("[TEST START]: PyNFS with GPFS")
         server_session, server_workspace, server_node = create_session
@@ -453,8 +510,13 @@ local-hostname: {vm_name}
         # NFS Ganesha Setup for GPFS
         # -----------------------
         logger.info("NFS Ganesha setup for GPFS tests")
+
+        flag_str = " ".join(cmake_flags)
+        logger.info("Using CMake flags: %s", flag_str)
+
         ganesha_setup = GPFSGaneshaManager(
-            session=vm_session
+            session=vm_session,
+            cmake_flags=flag_str
         )
         ganesha_setup.intall_pre_reqs_on_vm()
         ganesha_setup.install_ganesha("/root")


### PR DESCRIPTION
## Description

- Enabled centralised control of cmake flags
- Enabled fine tune of cmake flags for individual test basis
- Enabled common flags to be introduced to all the tests at one shot

## Changes

- ci_utils/config/cmake_flags.yml (New file)
- Lib & Test changes to adopt to the above functionality

## Logs
- https://jenkins-nfs-ganesha.apps.ocp.cloud.ci.centos.org/view/WIP%20(Test%20only)/job/test-mani-gpfs/121/console
- 