### PR TITLE
[Enhancement]: Enable Dev test pipeline to customise and run test suite

### DIFF
--- a/ci_utils/ceph/ceph_setup.py
+++ b/ci_utils/ceph/ceph_setup.py
@@ -1,7 +1,7 @@
 import time
 import json
 
-from ci_utils.common.helpers import run_cmd
+from ci_utils.common.helpers import run_cmd, scp_copy
 
 from ci_utils.common.logger import get_logger
 logger = get_logger(__name__)
@@ -11,6 +11,7 @@ class CephGaneshaSetup:
     def __init__(
         self,
         session,
+        extra_sessions=None,
         disk_img="/tmp/ceph-disk.img",
         disk_size="35G",
         vg_name="ceph-vg",
@@ -34,6 +35,7 @@ class CephGaneshaSetup:
             timeout (int): Timeout in seconds for waiting operations. 0 means no timeout.
         """
         self.session = session
+        self.extra_sessions = extra_sessions if extra_sessions else []
         self.disk_img = disk_img
         self.disk_size = disk_size
         self.vg_name = vg_name
@@ -48,24 +50,29 @@ class CephGaneshaSetup:
     # Disk + LVM Setup
     # -----------------------
     def setup_virtual_disks(self):
-        logger.info("[STEP]: Setting up virtual disks and LVMs")
-        run_cmd(self.session, f"truncate -s {self.disk_size} {self.disk_img}")
-        run_cmd(self.session, f"losetup -f {self.disk_img}")
-        loop_dev, _ = run_cmd(self.session, f"losetup -j {self.disk_img} | cut -d: -f1")
-        run_cmd(self.session, f"pvcreate {loop_dev}")
-        run_cmd(self.session, f"vgcreate {self.vg_name} {loop_dev}")
-        for i in range(1, self.osd_count + 1):
-            run_cmd(self.session, f"lvcreate -L 10G -n osd{i} {self.vg_name}")
-        logger.info("[OK] Virtual disks and LVMs created")
+        target_sessions = [self.session] + self.extra_sessions 
+        for sess in target_sessions:
+            logger.info("[STEP]: Setting up virtual disks and LVMs")
+            run_cmd(sess, f"truncate -s {self.disk_size} {self.disk_img}")
+            run_cmd(sess, f"losetup -f {self.disk_img}")
+            loop_dev, _ = run_cmd(sess, f"losetup -j {self.disk_img} | cut -d: -f1")
+            run_cmd(sess, f"pvcreate {loop_dev}")
+            run_cmd(sess, f"vgcreate {self.vg_name} {loop_dev}")
+            for i in range(1, self.osd_count + 1):
+                run_cmd(sess, f"lvcreate -L 10G -n osd{i} {self.vg_name}")
+            logger.info("[OK] Virtual disks and LVMs created")
 
     # -----------------------
     # Ceph Bootstrap
     # -----------------------
     def bootstrap_ceph(self):
+        target_sessions = [self.session] + self.extra_sessions 
+        for sess in target_sessions:
+            run_cmd(sess, "dnf install -y cephadm")
+            run_cmd(sess, "cephadm add-repo --release squid")
+            run_cmd(sess, "dnf install -y ceph")
+
         logger.info("[STEP]: Bootstrapping Ceph cluster")
-        run_cmd(self.session, "dnf install -y cephadm")
-        run_cmd(self.session, "cephadm add-repo --release squid")
-        run_cmd(self.session, "dnf install -y ceph")
         run_cmd(
             self.session,
             "cephadm bootstrap --mon-ip $(hostname -I | awk '{print $1}') "
@@ -78,13 +85,87 @@ class CephGaneshaSetup:
         )
         logger.info("[OK] Ceph cluster bootstrapped")
 
+    def add_extra_hosts(self):
+        if not self.extra_sessions:
+            logger.info("[SKIP] No extra Ceph hosts provided.")
+            return
+
+        logger.info(f"[STEP] Adding {len(self.extra_sessions)} extra Ceph hosts")
+
+        # Pack ceph configs for shipping
+        run_cmd(self.session, "tar czf /tmp/ceph_conf.tgz /etc/ceph")
+
+        # -------------------------------------------------------------------
+        # 1) Ensure SSH key exists for scp + cephadm
+        # -------------------------------------------------------------------
+        run_cmd(
+            self.session,
+            "test -f /root/.ssh/id_ed25519.pub || "
+            "(mkdir -p /root/.ssh && ssh-keygen -t ed25519 -N '' -f /root/.ssh/id_ed25519)"
+        )
+
+        # Read ssh key
+        ssh_pubkey, _ = run_cmd(self.session, "cat /root/.ssh/id_ed25519.pub")
+
+        # Read ceph orchestrator pubkey
+        ceph_pubkey, _ = run_cmd(self.session, "cat /etc/ceph/ceph.pub")
+        public_nw, _ = run_cmd(self.session, "echo $(ipcalc -n $(ip -o -4 addr show scope global | awk '{print $4}') | cut -d= -f2)/$(ip -o -4 addr show scope global | awk '{print $4}' | cut -d/ -f2)")
+        run_cmd(self.session, f"ceph config set global public_network {public_nw}")
+        
+        for sess in self.extra_sessions:
+
+            # -------------------------------------------------------------------
+            # 2) Install authorized_keys on extra node
+            # -------------------------------------------------------------------
+            run_cmd(sess, "mkdir -p /root/.ssh")
+            run_cmd(sess, f"echo '{ssh_pubkey.strip()}' >> /root/.ssh/authorized_keys")
+            run_cmd(sess, f"echo '{ceph_pubkey.strip()}' >> /root/.ssh/authorized_keys")
+            run_cmd(sess, "chmod 600 /root/.ssh/authorized_keys")
+
+            # -------------------------------------------------------------------
+            # 3) Copy ceph config bundle using scp
+            # -------------------------------------------------------------------
+            run_cmd(
+                self.session,
+                f"scp -o StrictHostKeyChecking=no /tmp/ceph_conf.tgz "
+                f"root@{sess.node_ip}:/tmp/"
+            )
+
+            # Extract on extra node
+            run_cmd(sess, "tar xzf /tmp/ceph_conf.tgz -C /")
+
+            run_cmd(
+                self.session,
+                f"scp -o StrictHostKeyChecking=no /var/lib/ceph/bootstrap-osd/ceph.keyring "
+                f"root@{sess.node_ip}:/var/lib/ceph/bootstrap-osd/"
+            )
+
+            # Set public network on extra node
+            public_nw, _ = run_cmd(sess, "echo $(ipcalc -n $(ip -o -4 addr show scope global | awk '{print $4}') | cut -d= -f2)/$(ip -o -4 addr show scope global | awk '{print $4}' | cut -d/ -f2)")
+            run_cmd(sess, f"ceph config set global public_network {public_nw}")
+
+            # -------------------------------------------------------------------
+            # 4) Add host to ceph orch
+            # -------------------------------------------------------------------
+            host_ip, _ = run_cmd(sess, "hostname -I | awk '{print $1}'")
+            hostname, _ = run_cmd(sess, "hostname")
+            run_cmd(self.session, f"ceph orch host add {hostname.strip()} {host_ip.strip()}")
+            run_cmd(self.session, "ceph orch host ls")
+
+
     # -----------------------
     # OSD Setup
     # -----------------------
     def setup_osds(self):
         logger.info("[STEP]: Setting up OSDs")
-        for i in range(1, self.osd_count + 1):
-            run_cmd(self.session, f"ceph-volume lvm create --data /dev/{self.vg_name}/osd{i}")
+
+
+        target_sessions = [self.session] + self.extra_sessions
+
+        for sess in target_sessions:
+            for i in range(1, self.osd_count + 1):
+                run_cmd(sess, f"ceph-volume lvm create --data /dev/{self.vg_name}/osd{i}")
+                        
         run_cmd(self.session, "ceph orch device ls")
         run_cmd(self.session, "ceph orch apply osd --all-available-devices")
 
@@ -153,6 +234,7 @@ class CephGaneshaSetup:
         """
         self.setup_virtual_disks()
         self.bootstrap_ceph()
+        self.add_extra_hosts()
         self.setup_osds()
         self.setup_cephfs()
         self.install_build_dependencies()

--- a/ci_utils/common/duffy_client.py
+++ b/ci_utils/common/duffy_client.py
@@ -7,7 +7,7 @@ from ci_utils.common.logger import get_logger
 logger = get_logger(__name__)
 
 class DuffySession:
-    def __init__(self, workspace=None, centos_version=None, centos_arch=None, metal_only=False):
+    def __init__(self, workspace=None, centos_version=None, centos_arch=None, metal_only=False, node_count=None):
         """
         Initialize Duffy client and configuration.
         Args:
@@ -20,7 +20,7 @@ class DuffySession:
         self.centos_version = centos_version or os.getenv("CENTOS_VERSION", "9")
         self.centos_arch = centos_arch or os.getenv("CENTOS_ARCH", "x86_64")
         self.metal_only = metal_only
-        self.node_count = int(os.getenv("NODE_COUNT", "1"))  # default = 1
+        self.node_count = node_count or int(os.getenv("NODE_COUNT", "1"))  # default = 1
         self.session_id = None
         self.nodes = []
 

--- a/ci_utils/common/helpers.py
+++ b/ci_utils/common/helpers.py
@@ -133,5 +133,5 @@ def run_cmd(session, cmd, check=True, timeout=3600, source_bashrc=False):
         logger.error(f"Command failed: {cmd_to_run}\n{err}")
         logger.error(f"Failure Output: {out}")
         raise RuntimeError(err)
-    logger.info(f"[REMOTE] Command output for {cmd_to_run} with return code {code}:\n {out.strip()}")
+    logger.info(f"[REMOTE] Command output for {cmd_to_run} with return code {code}: Output: {out.strip()} \n {err.strip()}\n")
     return out.strip(), code

--- a/ci_utils/cthon/cthon_setup.py
+++ b/ci_utils/cthon/cthon_setup.py
@@ -21,8 +21,8 @@ class CthonManager:
         self.repo_url = repo_url
         self.cthon_dir = "cthon04"
         if server_ip:
-            logger.info(f"[INFO] Using IP: {self.server_ip}")
             self.server_ip = server_ip
+            logger.info(f"[INFO] Using IP: {self.server_ip}")
         else:
             logger.info("[INFO] No server IP provided, using local hostname IP")
             self.server_ip, _ = run_cmd(self.session, "hostname -I | awk '{print $1}'")

--- a/ci_utils/dev_space/dependencies.py
+++ b/ci_utils/dev_space/dependencies.py
@@ -1,0 +1,76 @@
+from ci_utils.common.duffy_client import DuffySession
+
+from ci_utils.common.helpers import run_cmd
+from ci_utils.common.logger import get_logger
+from ci_utils.common.remote_session import RemoteSession
+logger = get_logger(__name__)
+
+def install_checkpatch_fsal_dependencies(session) -> None:
+    """
+    Install dependencies for Checkpatch, Clang, and FSAL on a remote node.
+
+    Args:
+        node_ip: IP of the remote node.
+        user: SSH user (default: root)
+
+    Raises:
+        RuntimeError: if installation fails
+    """
+
+    logger.info("Installing dependencies on remote node: %s", session)
+
+    # FSAL pre-requisites
+    cmd = "dnf -y install centos-release-ceph epel-release centos-release-gluster yum-utils"
+    _, code = run_cmd(session, cmd)
+    if code != 0:
+        raise RuntimeError(f"Failed to install FSAL dependencies on {session}")
+
+    # Determine CentOS version from Duffy session
+    duffy_session = DuffySession()
+    version = duffy_session.centos_version
+
+    basic_packages = "centos-release-gluster yum-utils centos-release-ceph epel-release"
+    build_requires_common = "git bison cmake dbus-devel flex gcc-c++ krb5-devel libacl-devel libblkid-devel libcap-devel redhat-rpm-config rpm-build xfsprogs-devel"
+    build_requires_extra_common = "libnsl2-devel libnfsidmap-devel libwbclient-devel userspace-rcu-devel"
+    build_requires_extra_cephfs_vfs_rgw = "libcephfs-devel"
+
+    install_cmd = (
+        f"dnf install --enablerepo=crb -y {basic_packages} "
+        f"{build_requires_common} {build_requires_extra_common} "
+        f"{build_requires_extra_cephfs_vfs_rgw}"
+    )
+
+    logger.info("Installing build dependencies for CentOS version: %s", version)
+    _, code = run_cmd(session, install_cmd)
+    if code != 0:
+        raise RuntimeError(f"Failed to install build dependencies on {session} (CentOS {version})")
+
+    logger.info("Dependencies installed successfully on %s", session)
+
+def setup_install_client_deps_cthon_pynfs(session):
+    logger.info("Installing dependencies on remote node for PyNFS & Cthon")
+    common_deps = "git gcc nfs-utils"
+    cthon_deps = "time make libtirpc-devel"
+    pynfs_deps = "redhat-rpm-config krb5-devel python3-devel python3-gssapi python3-ply"
+    _, code = run_cmd(session, f"yum --enablerepo=crb install -y {common_deps} {cthon_deps} {pynfs_deps}")
+    assert code == 0, f"Failed to install NFS client dependencies"
+
+def setup_server_node_pynfs_cthon(session):    
+    logger.info("Installing dependencies on remote node for PyNFS & Cthon")
+    _, code = run_cmd(session, "dnf -y install centos-release-ceph epel-release dnf-plugins-core")
+    assert code == 0, f"Failed to install dependencies for PyNFS & Cthon"
+
+    duffy_session = DuffySession()
+    version = duffy_session.centos_version
+
+    build_requires_cthon = "git bison cmake dbus-devel flex gcc-c++ krb5-devel libacl-devel libblkid-devel libcap-devel redhat-rpm-config rpm-build xfsprogs-devel lvm2 podman chrony"
+    build_requires_extra_cthon = "libnsl2-devel libnfsidmap-devel libwbclient-devel userspace-rcu-devel libcephfs-devel lua-devel"
+
+    if version.startswith("9"):
+        logger.info("Install packages for CentOS 9")
+        _, code = run_cmd(session, f"dnf install --enablerepo=crb -y {build_requires_cthon} {build_requires_extra_cthon}")
+        assert code == 0, f"Failed to install dependencies for CentOS 9"
+    else:
+        logger.info("Install packages for other CentOS")
+        _, code = run_cmd(session, f"dnf install --enablerepo=crb -y {build_requires_cthon} {build_requires_extra_cthon}")
+        assert code == 0, f"Failed to install dependencies for other CentOS"

--- a/ci_utils/dev_space/node_reservation.py
+++ b/ci_utils/dev_space/node_reservation.py
@@ -1,0 +1,120 @@
+import os
+import json
+from ci_utils.common.duffy_client import DuffySession
+
+from ci_utils.common.logger import get_logger
+logger = get_logger(__name__)
+
+WORKSPACE = os.getenv("WORKSPACE", "/tmp")
+SESSION_FILE = os.path.join(WORKSPACE, "duffy_session.json")
+BAREMETAL_SESSION_FILE = os.path.join(WORKSPACE, "baremetal_duffy_session.json")
+BAREMETAL_NODES = os.getenv("BAREMETAL_NODES", "false").lower()
+
+reserved_session = None
+
+def reserve_nodes(server_count=1, client_count=1):
+    """
+    Reserve server and client nodes separately and store in JSON.
+    
+    Args:
+        server_count (int): Number of server nodes to reserve
+        client_count (int): Number of client nodes to reserve
+    
+    Returns:
+        dict: {"servers": [...], "clients": [...]}
+    """
+    global reserved_session
+
+    logger.info("Starting node reservation...")
+    
+    # Initialize Duffy session
+    if BAREMETAL_NODES == "true":
+        session = DuffySession(workspace=WORKSPACE, metal_only=True)
+        session_file = BAREMETAL_SESSION_FILE
+    else:
+        session = DuffySession(workspace=WORKSPACE, node_count=server_count + client_count)
+        session_file = SESSION_FILE
+
+    # Reserve nodes
+    nodes = session.create()
+    logger.info("Total reserved nodes: %s", nodes)
+
+    # Segregate nodes into server and client lists
+    if len(nodes) < server_count + client_count:
+        raise RuntimeError(
+            f"Not enough nodes reserved. Requested: "
+            f"{server_count} servers + {client_count} clients, got {len(nodes)} nodes"
+        )
+
+    servers = nodes[:server_count]
+    clients = nodes[server_count:server_count + client_count]
+
+    node_info = {
+        "session_id": str(session.session_id),
+        "servers": servers,
+        "clients": clients
+    }
+
+    # Save JSON for other tests to consume
+    with open(session_file, "w") as f:
+        json.dump(node_info, f, indent=2)
+
+    reserved_session = session
+    return node_info
+
+def delete_nodes():
+    """
+    Delete the reserved nodes stored in the session JSON file.
+    Called after all tests finish (teardown).
+    Safe to call even if no session file exists.
+    """
+
+    session_file = BAREMETAL_SESSION_FILE if BAREMETAL_NODES == "true" else SESSION_FILE
+
+    if not os.path.exists(session_file):
+        logger.warning(f"No session file '{session_file}' found. Nothing to delete.")
+        return
+
+    logger.info(f"Reading session file '{session_file}'")
+
+    try:
+        with open(session_file, "r") as f:
+            data = json.load(f)
+    except json.JSONDecodeError:
+        logger.error(f"Corrupted session file '{session_file}'. Cannot delete nodes.")
+        return
+
+    session_id = data.get("session_id")
+    nodes = data.get("nodes", [])
+
+    if not session_id:
+        logger.error(f"No valid session_id in '{session_file}'. Cannot delete nodes.")
+        return
+
+    logger.info(f"Releasing session {session_id} with nodes: {nodes}")
+
+    # If the in-memory session exists, use it (recommended)
+    global reserved_session
+    if reserved_session and reserved_session.session_id == int(session_id):
+        try:
+            reserved_session.delete()
+            logger.info("Nodes released via active DuffySession instance.")
+        except Exception as e:
+            logger.exception(f"Failed to release nodes: {e}")
+
+    else:
+        # Session was lost; recreate a DuffySession object
+        session = DuffySession(workspace=WORKSPACE)
+        session.session_id = int(session_id)
+        try:
+            session.delete()
+            logger.info("Nodes released via reconstructed session.")
+        except Exception as e:
+            logger.exception(f"Failed to release nodes: {e}")
+
+    # Remove session file
+    try:
+        os.remove(session_file)
+        logger.info(f"Deleted session file '{session_file}'.")
+    except Exception as e:
+        logger.warning(f"Could not delete session file '{session_file}': {e}")

--- a/jobs/Jenkinsfile.sanity_dev
+++ b/jobs/Jenkinsfile.sanity_dev
@@ -1,0 +1,69 @@
+pipeline {
+    agent { label 'cico-workspace' }
+
+    options {
+        disableConcurrentBuilds()
+        timestamps()
+    }
+
+    environment {
+        PATH = "$HOME/.local/bin:$PATH"
+        PYTHONPATH = "ci-tests"
+    }
+
+    stages {
+
+        stage('Checkout CI Tests') {
+            steps {
+                echo "Cloning CI repo: ${params.CI_REPO} (${params.CI_BRANCH})"
+
+                dir('ci-tests') {
+                    git url: params.CI_REPO, branch: params.CI_BRANCH
+                }
+            }
+        }
+
+        stage('Checkout NFS-Ganesha') {
+            steps {
+                echo "Cloning Ganesha repo: ${params.GIT_REPO} (${params.GIT_BRANCH})"
+                dir('nfs-ganesha') {
+                    git url: params.GIT_REPO, branch: params.GIT_BRANCH
+                    
+                    // Update submodules recursively
+                    sh '''
+                        echo "Updating submodules recursively"
+                        git submodule update --init --recursive
+                    '''
+                }
+            }
+        }
+
+        stage('Install Dependencies') {
+            steps {
+                sh '''
+                    python3 -m pip install --user --upgrade pip setuptools wheel
+                    python3 -m pip install --user -r ./ci-tests/ci_utils/requirements.txt
+                '''
+            }
+        }
+
+        stage('Run tests') {
+            steps {
+                script {
+                    def suiteFileMap = [
+                        "fsal_ceph": "ci-tests/tests/dev_space/test_fsal.py"
+                    ]
+
+                    def testFile = suiteFileMap[params.TEST_SUITE]
+
+                    echo "[PIPELINE]: Selected suite '${params.TEST_SUITE}' → ${testFile}"
+                
+                    sh """
+                        echo "[PIPELINE]: Reserving nodes for tests..."
+                        pytest -v -s ci-tests/tests/dev_space/${params.TEST_SUITE}.py --confcutdir=ci-tests/tests/dev_space
+                    """
+                }
+            }
+        }
+    }
+}

--- a/jobs/distributed_test_runner/sanity_dev.groovy
+++ b/jobs/distributed_test_runner/sanity_dev.groovy
@@ -1,0 +1,93 @@
+// ---------- PIPELINE JOB ----------
+pipelineJob('sanity_dev') {
+
+    description('Dynamic CI Test Pipeline with parametrized test suite, topology, repos, and CMake options')
+
+    parameters {
+
+        // Test suite
+        choiceParam(
+            'TEST_SUITE',
+            ['test_fsal'],
+            'Select which test suite to run'
+        )
+
+        // Server nodes count — only allow 1 or 2
+        choiceParam(
+            'SERVER_NODE_COUNT',
+            ['1', '2'],
+            'Number of server nodes to reserve'
+        )
+
+        // Client nodes count — only allow 1 or 2
+        choiceParam(
+            'CLIENT_NODE_COUNT',
+            ['1', '2'],
+            'Number of client nodes to reserve'
+        )
+
+        // CI test repo + branch
+        stringParam(
+            'CI_REPO',
+            'https://github.com/nfs-ganesha/ci-tests.git',
+            'Git repo containing CI test framework'
+        )
+        stringParam(
+            'CI_BRANCH',
+            'centos-ci',
+            'Branch for CI test framework'
+        )
+
+        // Ganesha repo + branch
+        stringParam(
+            'GIT_REPO',
+            'https://github.com/nfs-ganesha/nfs-ganesha.git',
+            'NFS-Ganesha source repo'
+        )
+        stringParam(
+            'GIT_BRANCH',
+            'next',
+            'NFS-Ganesha branch'
+        )
+
+        // CMake
+        stringParam(
+            'CMAKE_FLAGS',
+            '',
+            'Extra CMake flags'
+        )
+        booleanParam(
+            'CMAKE_OVERRIDE',
+            false,
+            'Override default CMake flags'
+        )
+
+        // OS Version
+        choiceParam(
+            'CENTOS_VERSION',
+            ['9s', '10s'],
+            'Select CentOS version'
+        )
+
+        choiceParam(
+            'CENTOS_ARCH',
+            ['x86_64'],
+            'Architecture'
+        )
+    }
+
+    definition {
+        cpsScm {
+            scm {
+                git {
+                    remote {
+                        // Static repo that stores ONLY the Jenkinsfiles
+                        url('https://github.com/nfs-ganesha/ci-tests.git')
+                    }
+                    branch('centos-ci')
+                }
+            }
+            scriptPath('jobs/Jenkinsfile.sanity_dev')
+        }
+    }
+}

--- a/tests/dev_space/test_fsal.py
+++ b/tests/dev_space/test_fsal.py
@@ -1,0 +1,242 @@
+import os
+import pathlib
+import pytest
+import yaml
+
+from ci_utils.ceph.ceph_setup import CephGaneshaSetup
+from ci_utils.common import remote_session
+from ci_utils.common.helpers import run_cmd, scp_copy
+from ci_utils.common.logger import get_logger, set_test_name
+from ci_utils.common.remote_session import RemoteSession
+from ci_utils.cthon.cthon_setup import CthonManager
+from ci_utils.dev_space.dependencies import install_checkpatch_fsal_dependencies, setup_install_client_deps_cthon_pynfs, setup_server_node_pynfs_cthon
+from ci_utils.dev_space.node_reservation import delete_nodes, reserve_nodes
+from ci_utils.nfs_ganesha.nfs_ganesha_setup import GaneshaManager
+from ci_utils.pynfs.pynfs_setup import PyNFSManager
+logger = get_logger(__name__)
+
+PARAM_KEYS = [
+    "TEST_SUITE",
+    "SERVER_NODE_COUNT",
+    "CLIENT_NODE_COUNT",
+    "CMAKE_FLAGS",
+    "CMAKE_OVERRIDE",
+    "CENTOS_VERSION",
+    "CENTOS_ARCH",
+]
+NFS_GANESHA_REPO = "/tmp/workspace/sanity_dev/nfs-ganesha"
+
+@pytest.fixture(scope="session", autouse=True)
+def ci_params():
+    params = {k: os.environ.get(k) for k in PARAM_KEYS}
+
+    params["SERVER_NODE_COUNT"] = int(params["SERVER_NODE_COUNT"])
+    params["CLIENT_NODE_COUNT"] = int(params["CLIENT_NODE_COUNT"])
+    params["CMAKE_OVERRIDE"] = params["CMAKE_OVERRIDE"] == "true"
+
+    return params
+
+@pytest.fixture(scope="session", autouse=True)
+def reserved_nodes(ci_params):
+    """
+    Reserve nodes ONCE per pytest session,
+    and always release even if tests fail.
+    """
+    server_count = ci_params["SERVER_NODE_COUNT"]
+    client_count = ci_params["CLIENT_NODE_COUNT"]
+
+    logger.info("Reserving nodes: %s server, %s client", server_count, client_count)
+
+    # --- SETUP ---
+    nodes = reserve_nodes(server_count, client_count)
+    logger.info("Reserved nodes: %s", nodes)
+
+    yield nodes   # Tests will run after this point
+
+    # --- TEARDOWN ---
+    logger.info("Releasing reserved nodes...")
+    try:
+        delete_nodes()
+    except Exception as e:
+        logger.error("Failed to release nodes: %s", e)
+
+# Create remote sessions once for all nodes
+@pytest.fixture(scope="session", autouse=True)
+def remote_sessions(reserved_nodes):
+    
+    sessions = {"servers": [], "clients": []}
+
+    # --- Setup: Connect to nodes ---
+    for node in reserved_nodes["servers"]:
+        logger.info(f"[RemoteSession] Connecting to server {node}")
+        rs = RemoteSession(node_ip=node, default_dir="/root/test_session")
+        rs.connect()
+        rs.run("mkdir -p /root/test_session")
+        sessions["servers"].append(rs)
+
+    for node in reserved_nodes["clients"]:
+        logger.info(f"[RemoteSession] Connecting to client {node}")
+        rs = RemoteSession(node_ip=node, default_dir="/root/test_session")
+        rs.connect()
+        rs.run("mkdir -p /root/test_session")
+        sessions["clients"].append(rs)
+
+    yield sessions  # tests use these
+
+    # --- Teardown: Close SSH sessions ---
+    for group in sessions.values():
+        for rs in group:
+            try:
+                rs.close()
+            except Exception:
+                pass
+
+@pytest.fixture(scope="session", autouse=True)
+def cmake_config():
+    # Find repo root based on THIS file's location
+    this_file = pathlib.Path(__file__).resolve()
+
+    # Navigate to ci_utils/config/cmake_flags.yml relative to this conftest
+    config_path = this_file.parent.parent.parent / "ci_utils" / "config" / "cmake_flags.yml"
+
+    if not config_path.exists():
+        raise FileNotFoundError(f"CMake flag config not found: {config_path}")
+
+    with config_path.open() as f:
+        return yaml.safe_load(f)
+    
+# -----------------------
+# Fixtures - Test level
+# -----------------------
+@pytest.fixture(autouse=True)
+def attach_test_name(request):
+    logger.info("[Fixtures - Test]: Setting test name for logging")
+    set_test_name(request.node.name)
+
+@pytest.fixture
+def cmake_flags(request, cmake_config):
+    # Optional test-name override
+    forced_test_name = getattr(request, "param", None)
+
+    # Default behavior: real PyTest node name
+    test_name = forced_test_name or request.node.name
+
+    yaml_default = cmake_config.get("default", [])
+    yaml_test_specific = cmake_config.get("tests", {}).get(test_name, [])
+    logger.info(f"[CMake Flags] YAML test-specific for {test_name}: {yaml_test_specific}")
+
+    # ENV variable: general flags
+    env_flags = os.getenv("CMAKE_FLAGS", "")
+    env_flags_list = env_flags.split(",") if env_flags else []
+
+    # ENV override?
+    override = os.getenv("CMAKE_OVERRIDE", "").lower() in ("1", "true", "yes")
+
+    if override:
+        # Jenkins wants to ignore YAML entirely
+        return env_flags_list
+
+    # Merge YAML and CLI (YAML first, then CLI append / override)
+    return yaml_default + yaml_test_specific +  env_flags_list
+
+# -------------------------
+## Actual tests starts here
+# -------------------------
+@pytest.mark.parametrize("cmake_flags", ["test_fsal_cephfs"], indirect=True)
+def test_cephfs_fsal(remote_sessions, reserved_nodes, cmake_flags):
+    server = remote_sessions["servers"][0]
+    server_ip = reserved_nodes["servers"][0]
+    root_ganesha = "/root/nfs-ganesha"
+
+    logger.info("Remote Sessions: %s", remote_sessions)
+
+    flag_str = " ".join(cmake_flags)
+    logger.info("Using CMake flags: %s", flag_str)
+
+    logger.info("Starting FSAL CephFS test on server: %s", server_ip)
+    scp_copy(server_ip, f"{NFS_GANESHA_REPO}/", remote_dir="/root")
+    install_checkpatch_fsal_dependencies(server)
+    run_cmd(server, f"ls -la {root_ganesha}")
+    _, code = run_cmd(
+        server,
+        f"cd {root_ganesha} && "
+        "rm -rf build && "
+        "mkdir -p build && "
+        "cd build && "
+        f"cmake ../src {flag_str} && "
+        "make", check=False
+    )
+    logger.info("Build completed with code: %s", code)
+
+    assert code == 0, f"FSAL CephFS tests failed"
+
+
+@pytest.mark.timeout(1200) 
+def test_bringup_cephfs(remote_sessions, reserved_nodes):
+    try:
+        logger.info("[TEST START]: Cthon with CephFS")
+
+        server = remote_sessions["servers"][0]
+        server_ip = reserved_nodes["servers"][0]
+        root_ganesha = "/root/nfs-ganesha"
+
+        _, code = run_cmd(
+            server,
+            f"cd {root_ganesha} && cd build && "
+            "make install"
+        )
+
+        assert code == 0, f"Cthon Make CephFS tests failed"
+
+        logger.info(f"Installing dependencies on server node {server_ip}")
+        for sess in remote_sessions["servers"]:
+            setup_server_node_pynfs_cthon(sess)
+
+        logger.info("Ceph setup")
+        if len(remote_sessions["servers"]) > 1:
+            ceph_setup = CephGaneshaSetup(session=server, extra_sessions=remote_sessions["servers"][1:])
+        else:
+            ceph_setup = CephGaneshaSetup(session=remote_sessions["servers"][0])
+        subvol_path = ceph_setup.full_setup()
+
+        logger.info("NFS Ganesha setup")
+        ganesha_setup = GaneshaManager(
+            session=server,
+            subvol_path=subvol_path,
+            cephfs_name=ceph_setup.cephfs_name
+        )
+        ganesha_setup.setup()
+        assert f"CephFS setup completed"
+    except Exception as e:
+        logger.error(f"CephFS bringup failed: {e}")
+
+@pytest.mark.timeout(1200) 
+def test_cthon(remote_sessions, reserved_nodes):
+    logger.info("[TEST START]: Cthon with CephFS")
+
+    server_ip = reserved_nodes["servers"][0]
+    client = remote_sessions["clients"][0]
+    client_ip = reserved_nodes["clients"][0]    
+
+    setup_install_client_deps_cthon_pynfs(client)
+    logger.info("Running Cthon tests on node: %s", client_ip)
+    cthon = CthonManager(session=client, server_ip=server_ip)
+    cthon.clone_and_build()
+    _, rc = cthon.run_all_cthon_test(skip_v3=True)
+    
+    assert rc == 0, f"Cthon CephFS tests failed"
+
+def test_pynfs(remote_sessions, reserved_nodes):
+    logger.info("[TEST START]: PyNFS with CephFS")
+
+    server_ip = reserved_nodes["servers"][0]
+    client = remote_sessions["clients"][0]
+    client_ip = reserved_nodes["clients"][0]    
+
+    setup_install_client_deps_cthon_pynfs(client)
+    logger.info("Running PyNFS tests on node: %s", client_ip)
+    pynfs = PyNFSManager(session=client, server_ip=server_ip, backend_type="ceph")
+    _, failure_summary, code = pynfs.run_all_tests(export="/nfs/cephfs")
+    logger.info("PyNFS test failure summary: %s", failure_summary)
+    
+    assert code == 0, f"PyNFS CephFS tests failed"


### PR DESCRIPTION
# Description

To onboard NFS dev to leverage pytest framework to create their own test usecase without disturbing the existing CI workflow. Below are the new inclusions as part of this PR

1. Introduced separate Jenkins pipeline in CentOS Env with Ceph as a backend
2. Customised below flags in the job
     - To pass multiple server and multiple client (Currently restricted only with 2 server and 2 client max)
     - To select the test suite that is needed of their own choice
     - To pass custom cmake flags else to consume the same existing flag
     - Can pass their local github repo to pick the local changes
 3. Modified existing ceph lib to support multi server installation and bringup
 4. Introduced new test suite path for the dev to create tests `tests/dev_space/`
 5. Introduced groovy seed job to capture the pipeline changes `jobs/distributed_test_runner/sanity_dev.groovy`
 6. Common lib development still under `ci_utils`
 7. Dev specific lib development goes under `ci_utils/dev_space/dependencies.py`

# Logs

- Dev Pipeline Log: https://jenkins-nfs-ganesha.apps.ocp.cloud.ci.centos.org/view/all/job/sanity_dev/49/ 
- Gatecheck Pipeline Log: https://jenkins-nfs-ganesha.apps.ocp.cloud.ci.centos.org/view/WIP%20(Test%20only)/job/test-mani-gpfs/122/consoleFull