### PR TITLE
Add dictionary to configure delegations and async

### DIFF
--- a/ci_utils/nfs_ganesha/nfs_ganesha_setup.py
+++ b/ci_utils/nfs_ganesha/nfs_ganesha_setup.py
@@ -10,7 +10,7 @@ class GaneshaManager:
     """
     NFS-Ganesha Setup and Management for CephFS
     """
-    def __init__(self, session, subvol_path, cephfs_name="cephfs", export_id=101, test_type=None):
+    def __init__(self, session, subvol_path, ganesha_opts=None, cephfs_name="cephfs", export_id=101, test_type=None):
         """
         Manage NFS-Ganesha setup on a remote session.
 
@@ -24,17 +24,31 @@ class GaneshaManager:
         self.cephfs_name = cephfs_name
         self.export_id = export_id
         self.test_type = test_type
+        self.ganesha_opts = ganesha_opts or {}
+
+        self.conf = self._generate_conf()
 
     # ------------------------
     # Internal helpers
     # ------------------------
     def _generate_conf(self):
-        delegations_v4 = ""
-        delegations_export = ""
 
-        if self.test_type == "pynfs":
-            delegations_v4 = "    Delegations = true;"
-            delegations_export = "    delegations = readwrite;"
+        # ---- defaults ----
+        deleg_v4 = "true"
+        deleg_export = "none"
+        ceph_async = "true"
+
+        # ---- override only if ganesha_opts are passed ----
+        if self.ganesha_opts:
+            if "delegations_v4" in self.ganesha_opts:
+                deleg_v4 = self.ganesha_opts["delegations_v4"]
+
+            if "delegations_export" in self.ganesha_opts:
+                deleg_export = self.ganesha_opts["delegations_export"]
+
+            if "ceph_async" in self.ganesha_opts:
+                ceph_async = self.ganesha_opts["ceph_async"]
+
         return f"""NFS_CORE_PARAM {{
     Enable_NLM = true;
     Enable_RQUOTA = false;
@@ -43,11 +57,15 @@ class GaneshaManager:
 
 NFSv4 {{
     Enforce_UTF8_Validation = true;
-    {delegations_v4}
+    Delegations = {deleg_v4};
 }}
 
 EXPORT_DEFAULTS {{
     Access_Type = RW;
+}}
+
+CEPH {{
+    async = {ceph_async};
 }}
 
 EXPORT {{
@@ -58,19 +76,19 @@ EXPORT {{
     Transports = TCP;
     Access_Type = RW;
     Squash = None;
-    {delegations_export}
+    delegations = {deleg_export};
     FSAL {{
         Name = "CEPH";
     }}
 }}"""
+
 
     # ------------------------
     # Public methods
     # ------------------------
     def write_conf(self):
         """Write ganesha.conf to remote system."""
-        conf_content = self._generate_conf()
-        run_cmd(self.session, f"echo '{conf_content}' > /etc/ganesha/ganesha.conf")
+        run_cmd(self.session, f"echo '{self.conf}' > /etc/ganesha/ganesha.conf")
         run_cmd(self.session, "cat /etc/ganesha/ganesha.conf")
         logger.info("[OK] ganesha.conf written")
 

--- a/tests/dev_space/test_fsal.py
+++ b/tests/dev_space/test_fsal.py
@@ -170,11 +170,32 @@ def test_cephfs_fsal(remote_sessions, reserved_nodes, cmake_flags):
     )
     logger.info("Build completed with code: %s", code)
 
+    logger.info(f"Installing dependencies on server node {server_ip}")
+    for sess in remote_sessions["servers"]:
+        setup_server_node_pynfs_cthon(sess)
+
     assert code == 0, f"FSAL CephFS tests failed"
 
+@pytest.fixture(scope="session")
+def ceph_setup_data(remote_sessions):
+    server = remote_sessions["servers"][0]
+
+    if len(remote_sessions["servers"]) > 1:
+        ceph_setup = CephGaneshaSetup(
+            session=server,
+            extra_sessions=remote_sessions["servers"][1:]
+        )
+    else:
+        ceph_setup = CephGaneshaSetup(session=server)
+
+    # --- CACHE ---
+    ceph_setup._is_setup_done = False
+    ceph_setup._subvol_path = None
+
+    return ceph_setup
 
 @pytest.mark.timeout(1200) 
-def test_bringup_cephfs(remote_sessions, reserved_nodes):
+def test_bringup_cephfs(remote_sessions, reserved_nodes, ceph_setup_data):
     try:
         logger.info("[TEST START]: Cthon with CephFS")
 
@@ -190,22 +211,27 @@ def test_bringup_cephfs(remote_sessions, reserved_nodes):
 
         assert code == 0, f"Cthon Make CephFS tests failed"
 
-        logger.info(f"Installing dependencies on server node {server_ip}")
-        for sess in remote_sessions["servers"]:
-            setup_server_node_pynfs_cthon(sess)
-
         logger.info("Ceph setup")
-        if len(remote_sessions["servers"]) > 1:
-            ceph_setup = CephGaneshaSetup(session=server, extra_sessions=remote_sessions["servers"][1:])
-        else:
-            ceph_setup = CephGaneshaSetup(session=remote_sessions["servers"][0])
-        subvol_path = ceph_setup.full_setup()
+
+        ceph_setup = ceph_setup_data
+
+        if not ceph_setup._is_setup_done:
+            ceph_setup._subvol_path = ceph_setup.full_setup()
+            ceph_setup._is_setup_done = True
+
+        subvol_path = ceph_setup._subvol_path
+        cephfs_name = ceph_setup.cephfs_name
 
         logger.info("NFS Ganesha setup")
         ganesha_setup = GaneshaManager(
             session=server,
             subvol_path=subvol_path,
-            cephfs_name=ceph_setup.cephfs_name
+            cephfs_name=cephfs_name,   # <-- CHANGED
+            ganesha_opts={
+            "delegations_v4": "true",
+            "delegations_export": "readwrite",
+            "ceph_async": "false",
+            }
         )
         ganesha_setup.setup()
         assert f"CephFS setup completed"
@@ -224,9 +250,41 @@ def test_cthon(remote_sessions, reserved_nodes):
     logger.info("Running Cthon tests on node: %s", client_ip)
     cthon = CthonManager(session=client, server_ip=server_ip)
     cthon.clone_and_build()
-    _, rc = cthon.run_all_cthon_test(skip_v3=True)
+    _, _, rc = cthon.run_all_cthon_test(skip_v3=True)
     
     assert rc == 0, f"Cthon CephFS tests failed"
+
+@pytest.mark.timeout(1200)
+def test_delegation(remote_sessions, ceph_setup_data):
+    logger.info("[TEST START]: Update ganesha conf with delegation parameters")
+
+    server = remote_sessions["servers"][0]
+
+    ceph_setup = ceph_setup_data
+
+    # --- CACHED SETUP ---
+    if not ceph_setup._is_setup_done:
+        ceph_setup._subvol_path = ceph_setup.full_setup()
+        ceph_setup._is_setup_done = True
+
+    subvol_path = ceph_setup._subvol_path
+    cephfs_name = ceph_setup.cephfs_name
+
+    ganesha_setup = GaneshaManager(
+        session=server,
+        subvol_path=subvol_path,
+        cephfs_name=cephfs_name,
+        ganesha_opts={
+            "delegations_v4": "true",
+            "delegations_export": "readwrite",
+            "ceph_async": "false",
+        }
+    )
+
+    ganesha_setup.write_conf()
+    ganesha_setup.restart()
+
+    logger.info("Delegation updation completed")
 
 def test_pynfs(remote_sessions, reserved_nodes):
     logger.info("[TEST START]: PyNFS with CephFS")
@@ -240,5 +298,5 @@ def test_pynfs(remote_sessions, reserved_nodes):
     pynfs = PyNFSManager(session=client, server_ip=server_ip, backend_type="ceph")
     _, failure_summary, code = pynfs.run_all_tests(export="/nfs/cephfs")
     logger.info("PyNFS test failure summary: %s", failure_summary)
-    
+
     assert code == 0, f"PyNFS CephFS tests failed"

--- a/tests/test_pynfs_cthon.py
+++ b/tests/test_pynfs_cthon.py
@@ -300,7 +300,12 @@ def test_pynfs_cephfs(create_session, cmake_flags):
             session=server_session,
             subvol_path=subvol_path,
             cephfs_name=ceph_setup.cephfs_name,
-            test_type="pynfs"
+            test_type="pynfs",
+            ganesha_opts={
+                "delegations_v4": "true",
+                "delegations_export": "readwrite",
+                "ceph_async": "false",
+            }
         )
         ganesha_setup.setup()
 


### PR DESCRIPTION
By default, GaneshaManager generates a standard configuration with default values:

Delegations = true, delegations = readwrite

When ganesha_opts is provided, any of the following keys can override the defaults:

delegations_v4: overrides the NFSv4 Delegations setting

delegations_export: overrides the delegations setting in the EXPORT block

ceph_async: overrides the async value in the CEPH block

If ganesha_opts is empty or not provided, the existing configuration generation remains unchanged.

This allows tests and setups to programmatically customize NFS-Ganesha configuration without manually editing the config file or creating separate templates.

It keeps backward compatibility while supporting
flexible overrides.