### PR TITLE
(new_feature): Enable centos10 support for gatecheck

### DIFF
--- a/ci_utils/gpfs/gpfs_setup.py
+++ b/ci_utils/gpfs/gpfs_setup.py
@@ -146,7 +146,16 @@ class SpectrumScaleInstaller:
                 "rpcbind sssd-tools openldap-clients bind-utils net-tools "
                 "krb5-workstation python3 --skip-broken"
             )
-            run_cmd(sess, "python3 -m pip install --user ansible cherrypy")
+            version, _ = run_cmd(self.session, "rpm -E %{rhel}")
+            version = version.strip()
+            logger.info("CentOS Version for VM: %s", version)
+            if version.startswith("9"):
+                run_cmd(sess, "python3 -m pip install --user ansible cherrypy")
+            elif version.startswith("10"):
+                run_cmd(sess, "python3 -m pip install --user 'ansible-core==2.18.*' cherrypy")
+            else:
+                run_cmd(sess, "python3 -m pip install --user 'ansible-core==2.18.*' cherrypy")
+                
             logger.info(f"[INFO] Base packages installed on {node}")
 
         # Limit concurrency to avoid overloading network / SSH sessions
@@ -194,13 +203,13 @@ class SpectrumScaleInstaller:
         logger.info("[STEP]: Detecting usable IP addresses on the VM")
 
         # 1️⃣ Base IP
-        base_ip, _ = run_cmd(self.session, "/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1 | head -n1")
+        iface, _ = run_cmd(self.session, "ip -o -4 addr show up | awk '!/ lo / {print $2; exit}'")
+        base_ip, _ = run_cmd(self.session, f"/sbin/ip -o -4 addr list {iface} | awk '{{print $4}}' | cut -d/ -f1 | head -n1")
         base_ip = base_ip.strip()
         logger.info(f"Base IP detected: {base_ip}")
         subnet_prefix = ".".join(base_ip.split(".")[:3])
         servers = self.nodes.get("servers", [])
         required_ips = len(servers)
-        iface, _ = run_cmd(self.session, "ip -o -4 addr show up | awk '!/ lo / {print $2; exit}'")
         ip_cidr, _ = run_cmd(self.session, f"ip -o -4 addr show {iface} | awk '{{print $4}}' | head -n1")
         logger.info(f"Network interface: {iface.strip()}, CIDR: {ip_cidr}")
 

--- a/ci_utils/nfs_ganesha/gpfs_ganesha_setup.py
+++ b/ci_utils/nfs_ganesha/gpfs_ganesha_setup.py
@@ -74,9 +74,15 @@ class GPFSGaneshaManager:
 
         BASE_PACKAGES="git bison flex cmake gcc-c++ libacl-devel krb5-devel dbus-devel rpm-build redhat-rpm-config gdb"
         BUILDREQUIRES_EXTRA="libnsl2-devel libnfsidmap-devel libwbclient-devel userspace-rcu-devel libcephfs-devel python3-devel"
+        ADDITIONAL_PACKAGES=""
     
         if self.system_type == "centos":
             repo_name = "crb"
+            version, _ = run_cmd(self.session, "rpm -E %{rhel}")
+            version = version.strip()
+            logger.info("CentOS Version for GPFS: %s", version)
+            if version.startswith("10"):
+                ADDITIONAL_PACKAGES = "python3-build python3-wheel python3-installer"
         elif self.system_type == "baremetal" or self.system_type == "openstack":
             # Detect RHEL version and arch
             release_out, _ = run_cmd(self.session, "cat /etc/redhat-release")
@@ -91,7 +97,7 @@ class GPFSGaneshaManager:
             repo_name = f"codeready-builder-for-rhel-{rhel_major}-{arch.strip()}-rpms"
             run_cmd(self.session, f"subscription-manager repos --enable={repo_name}")
 
-        run_cmd(self.session, f"dnf install --enablerepo={repo_name} -y {BASE_PACKAGES} {BUILDREQUIRES_EXTRA} libacl-devel libblkid-devel libcap-devel redhat-rpm-config rpm-build libgfapi-devel xfsprogs-devel selinux-policy-devel sqlite --skip-broken")
+        run_cmd(self.session, f"dnf install --enablerepo={repo_name} -y {BASE_PACKAGES} {BUILDREQUIRES_EXTRA} {ADDITIONAL_PACKAGES} libacl-devel libblkid-devel libcap-devel redhat-rpm-config rpm-build libgfapi-devel xfsprogs-devel selinux-policy-devel sqlite --skip-broken")
         cmake_binary, _ = run_cmd(self.session, "which cmake")
         build_dir = f"{test_workspace}/nfs-ganesha/build"
         src_dir = f"{test_workspace}/nfs-ganesha"

--- a/ci_utils/virtual_machine/vm_setup.py
+++ b/ci_utils/virtual_machine/vm_setup.py
@@ -141,10 +141,31 @@ class VMManager:
         )
 
         iso_path = self.image_dir / "cloud-init.iso"
-        run_cmd(
-            self.session,
-            f"genisoimage -output {iso_path} -volid cidata -joliet -rock {cloud_dir}/user-data {cloud_dir}/meta-data"
-        )
+        version, _ = run_cmd(self.session, "rpm -E %{rhel}")
+        version = version.strip()
+        logger.info("CentOS Version for VM: %s", version)
+        if version.startswith("9"):
+            logger.info("Generating ISO image using genisoimage for CentOS 9")
+            run_cmd(
+                self.session,
+                f"genisoimage -output {iso_path} -volid cidata -joliet -rock {cloud_dir}/user-data {cloud_dir}/meta-data"
+            )
+        elif version.startswith("10"):
+            logger.info("Generating ISO image using xorriso for CentOS 10")
+            run_cmd(self.session, "dnf install -y xorriso")
+            run_cmd(
+                self.session,
+                f"xorriso -as mkisofs -output {iso_path} -volid cidata -joliet -rock "
+                f"{cloud_dir}/user-data {cloud_dir}/meta-data"
+            )
+        else:
+            logger.info("Generating ISO image using xorriso for CentOS 10")
+            run_cmd(self.session, "dnf install -y xorriso")
+            run_cmd(
+                self.session,
+                f"xorriso -as mkisofs -output {iso_path} -volid cidata -joliet -rock "
+                f"{cloud_dir}/user-data {cloud_dir}/meta-data"
+            )   
 
         return iso_path
 

--- a/tests/test_ci_pre_req.py
+++ b/tests/test_ci_pre_req.py
@@ -90,28 +90,33 @@ def test_install_dependencies_for_checkpatch_fsal(all_nodes):
     assert code == 0, f"Failed to install dependencies for checkpatch and Clang"
 
     logger.info("Installing dependencies on remote node for FSAL: %s", server_node)
-    _, code = run_cmd(session, "dnf -y install centos-release-ceph epel-release centos-release-gluster yum-utils")
+    _, code = run_cmd(session, "dnf -y install centos-release-ceph epel-release yum-utils")
     assert code == 0, f"Failed to install dependencies for FSAL"
 
     duffy_session = DuffySession()
     version = duffy_session.centos_version
 
-    basic_packages = "centos-release-gluster yum-utils centos-release-ceph epel-release"
+    basic_packages = "yum-utils centos-release-ceph epel-release"
 
     build_requires_common = "git bison cmake dbus-devel flex gcc-c++ krb5-devel libacl-devel libblkid-devel libcap-devel redhat-rpm-config rpm-build xfsprogs-devel"
-    build_requires_gpfs_vfs = "libgfapi-devel"
+    build_requires_gpfs_vfs = ""
 
     build_requires_extra_common = "libnsl2-devel libnfsidmap-devel libwbclient-devel userspace-rcu-devel"
     build_requires_extra_cephfs_vfs_rgw = "libcephfs-devel"
     build_requires_extra_rgw = "librgw-devel"
+    build_requires_extra_centos10 = "python3-build python3-wheel"
 
     if version.startswith("9"):
         logger.info("Install packages for CentOS 9")
         _, code = run_cmd(session, f"dnf install --enablerepo=crb -y {basic_packages} {build_requires_common} {build_requires_gpfs_vfs} {build_requires_extra_common} {build_requires_extra_cephfs_vfs_rgw} {build_requires_extra_rgw}")
         assert code == 0, f"Failed to install dependencies for CentOS 9"
+    elif version.startswith("10"):
+        logger.info("Install packages for CentOS 10")
+        _, code = run_cmd(session, f"dnf install --enablerepo=crb -y {basic_packages} {build_requires_common} {build_requires_gpfs_vfs} {build_requires_extra_common} {build_requires_extra_cephfs_vfs_rgw} {build_requires_extra_rgw} {build_requires_extra_centos10}")
+        assert code == 0, f"Failed to install dependencies for CentOS 10"
     else:
         logger.info("Install packages for other CentOS")
-        _, code = run_cmd(session, f"dnf install --enablerepo=crb -y {basic_packages} {build_requires_common} {build_requires_gpfs_vfs} {build_requires_extra_common} {build_requires_extra_cephfs_vfs_rgw} {build_requires_extra_rgw}")
+        _, code = run_cmd(session, f"dnf install --enablerepo=crb -y {basic_packages} {build_requires_common} {build_requires_gpfs_vfs} {build_requires_extra_common} {build_requires_extra_cephfs_vfs_rgw} {build_requires_extra_rgw} {build_requires_extra_centos10}")
         assert code == 0, f"Failed to install dependencies for other CentOS"
 
 
@@ -140,11 +145,16 @@ def setup_node_pynfs_cthon(server_node):
 
     build_requires_cthon = "git bison cmake dbus-devel flex gcc-c++ krb5-devel libacl-devel libblkid-devel libcap-devel redhat-rpm-config rpm-build xfsprogs-devel lvm2"
     build_requires_extra_cthon = "libnsl2-devel libnfsidmap-devel libwbclient-devel userspace-rcu-devel libcephfs-devel lua-devel"
+    build_requires_extra_centos10 = "python3-build python3-wheel"
 
     if version.startswith("9"):
         logger.info("Install packages for CentOS 9")
         _, code = run_cmd(session, f"dnf install --enablerepo=crb -y {build_requires_cthon} {build_requires_extra_cthon}")
         assert code == 0, f"Failed to install dependencies for CentOS 9"
+    elif version.startswith("10"):
+        logger.info("Install packages for CentOS 10")
+        _, code = run_cmd(session, f"dnf install --enablerepo=crb -y {build_requires_cthon} {build_requires_extra_cthon} {build_requires_extra_centos10}")
+        assert code == 0, f"Failed to install dependencies for CentOS 10"
     else:
         logger.info("Install packages for other CentOS")
         _, code = run_cmd(session, f"dnf install --enablerepo=crb -y {build_requires_cthon} {build_requires_extra_cthon}")
@@ -154,7 +164,8 @@ def setup_node_vfs(server_node):
     session = RemoteSession(node_ip=server_node, user="root")
     
     logger.info("Installing dependencies on remote node for VFS %s", server_node)
-    run_cmd(session, "dnf -y install centos-release-gluster yum-utils centos-release-ceph epel-release rpcbind")
+    run_cmd(session, "dnf -y install yum-utils centos-release-ceph epel-release rpcbind")
+
 
     logger.info("Starting rpcbind service on remote node for VFS %s", server_node)
     run_cmd(session, "systemctl start rpcbind")
@@ -166,14 +177,19 @@ def setup_node_vfs(server_node):
     duffy_session = DuffySession() 
     version = duffy_session.centos_version
 
-    build_requires_vfs = "git bison flex cmake gcc-c++ libacl-devel krb5-devel dbus-devel rpm-build redhat-rpm-config gdb libblkid-devel libcap-devel libgfapi-devel xfsprogs-devel"
+    build_requires_vfs = "git bison flex cmake gcc-c++ libacl-devel krb5-devel dbus-devel rpm-build redhat-rpm-config gdb libblkid-devel libcap-devel xfsprogs-devel"
     build_requires_extra_vfs= "libnsl2-devel libnfsidmap-devel libwbclient-devel userspace-rcu-devel libcephfs-devel python3-devel"
     build_requires_add_on_vfs = "selinux-policy-devel sqlite"
+    build_requires_extra_centos10 = "python3-build python3-wheel"
 
     if version.startswith("9"):
         logger.info("Install packages for CentOS 9")
         _, code = run_cmd(session, f"dnf install --enablerepo=crb -y {build_requires_vfs} {build_requires_extra_vfs} {build_requires_add_on_vfs}")
         assert code == 0, f"Failed to install dependencies for CentOS 9"
+    elif version.startswith("10"):
+        logger.info("Install packages for CentOS 10")
+        _, code = run_cmd(session, f"dnf install --enablerepo=crb -y {build_requires_vfs} {build_requires_extra_vfs} {build_requires_add_on_vfs} {build_requires_extra_centos10}")
+        assert code == 0, f"Failed to install dependencies for CentOS 10"
     else:
         logger.info("Install packages for other CentOS")
         _, code = run_cmd(session, f"dnf install --enablerepo=crb -y {build_requires_vfs} {build_requires_extra_vfs} {build_requires_add_on_vfs}")

--- a/tests/test_pynfs_cthon.py
+++ b/tests/test_pynfs_cthon.py
@@ -364,10 +364,21 @@ def test_pynfs_gpfs(create_session, cmake_flags):
         logger.info("[TEST WORKSPACE DETAILS]:Server Workspace: %s", server_workspace)
         logger.info("[TEST SESSION DETAILS]: Server Session: %s", server_session)
 
+        version, _ = run_cmd(server_session, "rpm -E %{rhel}")
+        version = version.strip()
+        logger.info("CentOS Version for GPFS: %s", version)
+
         vm_name = "centos9-vm"
         username = "root"
         ssh_key = "/root/.ssh/id_rsa.pub"
-        version_constraints = "5.14.0-611.16.1.el9_7" #Assuming GPFS 6.0 https://www.ibm.com/docs/en/STXKQY/gpfsclustersfaq.html#fsi
+
+        if version.startswith("9"):
+            version_constraints = "5.14.0-611.16.1.el9_7" #Assuming GPFS 6.0 https://www.ibm.com/docs/en/STXKQY/gpfsclustersfaq.html#fsi
+        elif version.startswith("10"):
+            version_constraints = "6.12.0-124.11.1.el10_1" #Assuming GPFS 6.0 https://www.ibm.com/docs/en/STXKQY/gpfsclustersfaq.html#fsi
+        else:
+            version_constraints = "6.12.0-124.11.1.el10_1" #Assuming GPFS 6.0 https://www.ibm.com/docs/en/STXKQY/gpfsclustersfaq.html#fsi
+
         gerrit_host = os.getenv("GERRIT_HOST", "review.gerrithub.io")
         gerrit_project = os.getenv("GERRIT_PROJECT", "ffilz/nfs-ganesha")
         gerrit_refspec = os.getenv("GERRIT_REFSPEC", "")
@@ -387,7 +398,7 @@ def test_pynfs_gpfs(create_session, cmake_flags):
         # -----------------------
         # VM Setup
         # -----------------------
-        image_url = identify_matching_qcow_image(server_session, "x86_64", "9", "https://cloud.centos.org/centos/9-stream/x86_64/images/", version_constraints=version_constraints)
+        image_url = identify_matching_qcow_image(server_session, "x86_64", version, f"https://cloud.centos.org/centos/{version}-stream/x86_64/images/", version_constraints=version_constraints)
         logger.info("Image URL: %s", image_url)
 
         logger.info("Setting up VM on baremetal node: %s", server_node)


### PR DESCRIPTION
Enable centos10 support for gatecheck

## Known issues:
- Currently ceph does not provide rpm for 10 support. Expected to fail
- GPFS test cases fails because of https://review.gerrithub.io/c/ffilz/nfs-ganesha/+/1229368 (Not merged yet)

No pass log attached because of above said reasons

## Note:
Gatecheck will continue on CentOS-9