### PR TITLE
Fixes related to pynfs and GPFS workflow

### DIFF
--- a/ci_utils/nfs_ganesha/gpfs_ganesha_setup.py
+++ b/ci_utils/nfs_ganesha/gpfs_ganesha_setup.py
@@ -285,8 +285,18 @@ class GPFSGaneshaManager:
         run_cmd(self.session, "systemctl daemon-reload")
         run_cmd(self.session, "cat /var/mmfs/ces/nfs-config/gpfs.ganesha.main.conf")
         
+        # Validate enforce_utf8_validation and reload if false
+        logger.info("Checking enforce_utf8_validation value")
+        _, rc = run_cmd(self.session, "grep -i 'enforce_utf8_validation.*false' /var/mmfs/ces/nfs-config/gpfs.ganesha.main.conf", check=False)
+        if rc == 0:
+            logger.warning("enforce_utf8_validation is false, performing daemon-reload")
+            run_cmd(self.session, "systemctl daemon-reload")
+            time.sleep(20)
+            run_cmd(self.session, "cat /var/mmfs/ces/nfs-config/gpfs.ganesha.main.conf")
+        
         self.start_ganesha_service()
 
+        run_cmd(self.session, "cat /var/mmfs/ces/nfs-config/gpfs.ganesha.main.conf")
         logger.info("Validating health of CES and NFS services")
         run_cmd(self.session, "systemctl status nfs-ganesha.service", check=False)
         run_cmd(self.session, "cat /etc/ganesha/ganesha.conf", check=False)

--- a/ci_utils/pynfs/pynfs_setup.py
+++ b/ci_utils/pynfs/pynfs_setup.py
@@ -71,7 +71,6 @@ class PyNFSManager:
                     "WRT16",
                     "PUTFH3",
                     "LOCK20",
-                    "RNM20"
                 ]
             elif self.backend_type == "acl_vfs":
                 # BZ-2415390
@@ -79,9 +78,6 @@ class PyNFSManager:
                     "WRT17",
                     "WRT16",
                     "WRT18",
-                    "LOOKCHAR",
-                    "LOOKBLK",
-                    "SATT18",
                     "LOCK20",
                 ]
             elif self.backend_type == "gpfs":
@@ -106,16 +102,10 @@ class PyNFSManager:
                     "ALLOC1",
                     "ALLOC2",
                     "ALLOC3",
-                    "RNM20",
-                    "DELEG2",
-                    "DELEG23",
-                    "DELEG8",
                     "DELEG25",
                     "DELEG24",
                     "DELEG7",
                     "SEQ6",
-                    "CSESS21",
-                    "CSESS20",
                 ]
             elif self.backend_type == "acl_vfs":
                 ## Adding no-deleg option to skip delegation tests for VFS backends BZ-2415392
@@ -125,19 +115,7 @@ class PyNFSManager:
                     f" --secure --verbose --maketree --showomit --rundeps"
                 )
                 known_failures = [
-                    "PUTFH1c",
-                    "PUTFH1b",
-                    "RNM1c",
-                    "RNM1b",
-                    "RNM2c",
-                    "RNM2b",
-                    "RNM3c",
-                    "RNM3b",
-                    "LKPP1c",
-                    "LKPP1b",
                     "SEQ6",
-                    "CSESS21",
-                    "CSESS20",
                 ]
             elif self.backend_type == "gpfs":
                 # BZ-2416757
@@ -158,14 +136,12 @@ class PyNFSManager:
                     "DELEG8",
                     "DELEG25",
                     "DELEG24",
+                    "DELEG26",
                     "DELEG6",
                     "DELEG7",
                     "DELEG5",
                     "DELEG3",
                     "SEQ6",
-                    "CSESS21",
-                    "CSESS20",
-                    "EID9"
                 ]
         else:
             raise ValueError(f"Unsupported NFS version: {version}")

--- a/ci_utils/vfs/vfs_setup.py
+++ b/ci_utils/vfs/vfs_setup.py
@@ -55,6 +55,7 @@ EXPORT {{
     FSAL {{
         Name = VFS;
     }}
+    Squash = no_root_squash;
 }}
 """
 

--- a/jobs/Jenkinsfile.weekly_ceph
+++ b/jobs/Jenkinsfile.weekly_ceph
@@ -77,12 +77,16 @@ pipeline {
                 echo "Cloning Ganesha repo: ${params.GIT_REPO} (${params.GIT_BRANCH})"
 
                 dir('nfs-ganesha') {
-                    git url: params.GIT_REPO, branch: params.GIT_BRANCH
-
-                    sh '''
+                    sh """
+                        echo "Cloning repository..."
+                        git clone ${params.GIT_REPO} .
+                        
+                        echo "Checking out ${params.GIT_BRANCH}..."
+                        git checkout ${params.GIT_BRANCH}
+                        
                         echo "Updating submodules recursively"
                         git submodule update --init --recursive
-                    '''
+                    """
                 }
             }
         }
@@ -177,7 +181,7 @@ pipeline {
                                     'test_gpfs_pynfs': [
                                         name: 'GPFS_PyNFS',
                                         coverage: 'NFS v4.0, v4.1',
-                                        comment: ''
+                                        comment: 'IBMCEPH-14012'
                                     ],
                                     'test_gpfs_pjdfs': [
                                         name: 'GPFS_Pjdfs',

--- a/tests/test_weekly_ceph.py
+++ b/tests/test_weekly_ceph.py
@@ -145,6 +145,11 @@ def cmake_flags(request, cmake_config):
 
     # Default behavior: real PyTest node name
     test_name = forced_test_name or request.node.name
+    logger.info("[CMake Flags] DEBUG - request.param: %s", forced_test_name)
+    logger.info("[CMake Flags] DEBUG - request.node.name: %s", request.node.name)
+    logger.info("[CMake Flags] DEBUG - Final test_name: %s", test_name)
+    logger.info("[CMake Flags] DEBUG - Available YAML keys: %s", list(cmake_config.get("tests", {}).keys()))
+    logger.info("[CMake Flags] Test name: %s", test_name)
 
     yaml_default = cmake_config.get("default", [])
     yaml_test_specific = cmake_config.get("tests", {}).get(test_name, [])
@@ -209,9 +214,8 @@ def cephfs_env(remote_sessions):
     }
 
 @pytest.fixture(scope="module")
-@pytest.mark.parametrize("cmake_flags", ["test_fsal_gpfs"], indirect=True)
-def gpfs_env(remote_sessions, reserved_nodes, cmake_flags):
-    logger.info("\n" + "=" * 80 + "\n[Fixture] Setting up GPFS + Ganesha\n" + "=" * 80)
+def gpfs_env(remote_sessions, reserved_nodes):
+    logger.info("\n" + "=" * 80 + "\n[Fixture] Setting up GPFS Environment\n" + "=" * 80)
     
     server = remote_sessions["servers"][0]
     server_ip = reserved_nodes["servers"][0]
@@ -381,28 +385,10 @@ local-hostname: {vm_name}
     logger.debug("GPFS Installer info: %s", gpfs_installer)
     gpfs_installer.run()
     
-    # -----------------------
-    # NFS Ganesha Setup for GPFS
-    # -----------------------
-    logger.info("NFS Ganesha setup for GPFS tests")
-    
-    flag_str = " ".join(cmake_flags)
-    logger.info("Using CMake flags: %s", flag_str)
-    
-    ganesha_setup = GPFSGaneshaManager(
-        session=vm_session,
-        cmake_flags=flag_str
-    )
-    ganesha_setup.intall_pre_reqs_on_vm()
-    ganesha_setup.install_ganesha("/root")
-    ganesha_setup.export_nfs_volume()
-    ganesha_setup.start_ganesha_service()
-    
     return {
         "server": server,
         "vm_session": vm_session,
         "vm_ip": vm_ip,
-        "ganesha_setup": ganesha_setup,
         "gpfs_setup": gpfs_installer
     }
 
@@ -604,16 +590,43 @@ def test_pynfs(remote_sessions, reserved_nodes, cephfs_env):
 # # --------------------------------
 @pytest.mark.timeout(3600)
 @pytest.mark.dependency(name="test_bringup_gpfs")
-def test_bringup_gpfs(gpfs_env):
-    logger.info("\n" + "=" * 80 + "\n[TEST START]: Bringup GPFS\n" + "=" * 80)
+@pytest.mark.parametrize("cmake_flags", ["test_fsal_gpfs"], indirect=True)
+def test_bringup_gpfs(gpfs_env, cmake_flags):
+    """
+    Test GPFS bringup including FSAL build and NFS Ganesha setup.
+    Uses parametrized cmake flags from cmake_flags.yml (test_fsal_gpfs).
+    """
+    logger.info("\n" + "=" * 80 + "\n[TEST START]: Bringup GPFS with Ganesha\n" + "=" * 80)
     
-    ganesha_setup = gpfs_env["ganesha_setup"]
-    
-    # Get NFS-Ganesha version and write to file for Jenkins post section
-    nfs_version = ganesha_setup.get_nfs_version()
+    vm_session = gpfs_env["vm_session"]
     gpfs_setup = gpfs_env["gpfs_setup"]
     
-    # Get Ceph version and write to file for Jenkins post section
+    # -----------------------
+    # NFS Ganesha Setup for GPFS
+    # -----------------------
+    logger.info("NFS Ganesha setup for GPFS tests")
+    
+    flag_str = " ".join(cmake_flags)
+    logger.info("Using CMake flags for GPFS FSAL: %s", flag_str)
+    
+    ganesha_setup = GPFSGaneshaManager(
+        session=vm_session,
+        cmake_flags=flag_str
+    )
+    ganesha_setup.intall_pre_reqs_on_vm()
+    ganesha_setup.install_ganesha("/root")
+    ganesha_setup.export_nfs_volume()
+    ganesha_setup.start_ganesha_service()
+    
+    # Store ganesha_setup in gpfs_env for other tests to use
+    gpfs_env["ganesha_setup"] = ganesha_setup
+    
+    logger.info("GPFS FSAL build and Ganesha setup completed successfully")
+    
+    # -----------------------
+    # Get and write versions
+    # -----------------------
+    # Get GPFS version and write to file for Jenkins post section
     gpfs_version = gpfs_setup.get_gpfs_version()
     logger.info("GPFS version: %s", gpfs_version)
     
@@ -721,6 +734,8 @@ def test_gpfs_pynfs(remote_sessions, reserved_nodes, gpfs_env):
     vm_ip = gpfs_env["vm_ip"]
     server_ip = reserved_nodes["servers"][0]
     
+    setup_install_client_deps_cthon_pynfs(server)
+
     # Wait for NFS grace period
     logger.info("Waiting for 90 seconds before starting PyNFS tests as the NFS grace period is 90 seconds")
     sleep(90)


### PR DESCRIPTION
**Changes**
- ignore the DELEG26 in the exception list for gpfs
- remove the pynfs failures which are fixed
- Enable squash as no root squash for VFS backend
- Enable seperate git clone to support cloning of any tags or commits
- Enable Debug logs for CMake
- Fix Cmake for GPFS to use custom config

**Pass Logs:**

- https://jenkins-nfs-ganesha.apps.ocp.cloud.ci.centos.org/job/test-mani-1/33/consoleFull (Gatecheck)
- https://jenkins-nfs-ganesha.apps.ocp.cloud.ci.centos.org/job/test-weekly-mani/38/consoleFull (Weekly)