### PR TITLE
fix pynfs with gpfs on UTF-8 related config

### DIFF
--- a/ci_utils/nfs_ganesha/gpfs_ganesha_setup.py
+++ b/ci_utils/nfs_ganesha/gpfs_ganesha_setup.py
@@ -272,31 +272,25 @@ class GPFSGaneshaManager:
         run_cmd(self.session, "/usr/lpp/mmfs/bin/mmnfs export list")
 
         logger.info("Restarting NFS-Ganesha to apply changes for Minor versions and UTF8 enforcement")
-        run_cmd(self.session, "cat /var/mmfs/ces/nfs-config/gpfs.ganesha.main.conf")
+        main_conf = "/var/mmfs/ces/nfs-config/gpfs.ganesha.main.conf"
+        run_cmd(self.session, f"cat {main_conf}")
         run_cmd(self.session, "systemctl stop nfs-ganesha", check=False)
         run_cmd(self.session, "/usr/lpp/mmfs/bin/mmnfs config list |grep MINOR")
         run_cmd(self.session, "/usr/lpp/mmfs/bin/mmnfs config change MINOR_VERSIONS=0,1,2")
+        time.sleep(20)
+        run_cmd(self.session, "/usr/lpp/mmfs/bin/mmnfs config list |grep MINOR")
+        run_cmd(self.session, "systemctl daemon-reload")
+        run_cmd(self.session, f"cat {main_conf}")
+        run_cmd(self.session, "systemctl start nfs-ganesha", check=False)
+        run_cmd(self.session, "systemctl status nfs-ganesha.service", check=False)
+
+        # ENFORCE_UTF8 must run while ganesha is up; stopping before this leaves enforce_utf8_validation=false in main.conf
         run_cmd(self.session, "/usr/lpp/mmfs/bin/mmnfs config list |grep ENFORCE")
         run_cmd(self.session, "/usr/lpp/mmfs/bin/mmnfs config change ENFORCE_UTF8_VALIDATION=true")
         time.sleep(20)
-        run_cmd(self.session, "/usr/lpp/mmfs/bin/mmnfs config list |grep MINOR")
         run_cmd(self.session, "/usr/lpp/mmfs/bin/mmnfs config list |grep ENFORCE")
-        run_cmd(self.session, "/usr/lpp/mmfs/bin/mmnfs config list")
-        run_cmd(self.session, "systemctl daemon-reload")
-        run_cmd(self.session, "cat /var/mmfs/ces/nfs-config/gpfs.ganesha.main.conf")
-        
-        # Validate enforce_utf8_validation and reload if false
-        logger.info("Checking enforce_utf8_validation value")
-        _, rc = run_cmd(self.session, "grep -i 'enforce_utf8_validation.*false' /var/mmfs/ces/nfs-config/gpfs.ganesha.main.conf", check=False)
-        if rc == 0:
-            logger.warning("enforce_utf8_validation is false, performing daemon-reload")
-            run_cmd(self.session, "systemctl daemon-reload")
-            time.sleep(20)
-            run_cmd(self.session, "cat /var/mmfs/ces/nfs-config/gpfs.ganesha.main.conf")
-        
-        self.start_ganesha_service()
+        run_cmd(self.session, f"cat {main_conf}")
 
-        run_cmd(self.session, "cat /var/mmfs/ces/nfs-config/gpfs.ganesha.main.conf")
         logger.info("Validating health of CES and NFS services")
         run_cmd(self.session, "systemctl status nfs-ganesha.service", check=False)
         run_cmd(self.session, "cat /etc/ganesha/ganesha.conf", check=False)

--- a/jobs/Jenkinsfile.weekly_ceph
+++ b/jobs/Jenkinsfile.weekly_ceph
@@ -181,7 +181,7 @@ pipeline {
                                     'test_gpfs_pynfs': [
                                         name: 'GPFS_PyNFS',
                                         coverage: 'NFS v4.0, v4.1',
-                                        comment: 'IBMCEPH-14012'
+                                        comment: ''
                                     ],
                                     'test_gpfs_pjdfs': [
                                         name: 'GPFS_Pjdfs',


### PR DESCRIPTION
### Summary
Fixes inconsistent PyNFS GPFS CI failures caused by ENFORCE_UTF8_VALIDATION not being applied correctly during Spectrum Scale NFS export setup.

### Problem

The previous export_nfs_volume() flow in GPFSGaneshaManager applied GPFS CES NFS config in the wrong order. ENFORCE_UTF8_VALIDATION=true was changed while ganesha was stopped, so gpfs.ganesha.main.conf often kept enforce_utf8_validation=false. A post-hoc grep/daemon-reload workaround was unreliable and could leave ganesha in a bad state before PyNFS ran.

### Solution

Reordered the GPFS NFS configuration sequence in ci_utils/nfs_ganesha/gpfs_ganesha_setup.py:

Stop ganesha and apply MINOR_VERSIONS=0,1,2
Wait for config propagation, daemon-reload, and start ganesha
Apply ENFORCE_UTF8_VALIDATION=true while ganesha is running (required for GPFS to persist the setting)
Validate CES/NFS health before returning
Also removed the redundant enforce_utf8_validation grep/reload block

### Minor cleanup: 
cleared the stale IBMCEPH-14012 comment from the GPFS PyNFS entry in jobs/Jenkinsfile.weekly_ceph.

### Pass Log:
1. https://jenkins-nfs-ganesha.apps.ocp.cloud.ci.centos.org/job/test-mani-1/52/ (Gatecheck)
2. https://jenkins-nfs-ganesha.apps.ocp.cloud.ci.centos.org/job/test-weekly-mani/45/console (Weekly)