### PR TITLE
[CI]: Add dependancy openssl-devel and pin ceph to tentacle

### DIFF
--- a/ci_utils/dev_space/dependencies.py
+++ b/ci_utils/dev_space/dependencies.py
@@ -20,7 +20,7 @@ def install_checkpatch_fsal_dependencies(session) -> None:
     logger.info("Installing dependencies on remote node: %s", session)
 
     # FSAL pre-requisites
-    cmd = "dnf -y install centos-release-ceph epel-release centos-release-gluster yum-utils"
+    cmd = "dnf -y install centos-release-ceph-tentacle epel-release centos-release-gluster yum-utils"
     _, code = run_cmd(session, cmd)
     if code != 0:
         raise RuntimeError(f"Failed to install FSAL dependencies on {session}")
@@ -29,8 +29,8 @@ def install_checkpatch_fsal_dependencies(session) -> None:
     duffy_session = DuffySession()
     version = duffy_session.centos_version
 
-    basic_packages = "centos-release-gluster yum-utils centos-release-ceph epel-release"
-    build_requires_common = "git bison cmake dbus-devel flex gcc-c++ krb5-devel libacl-devel libblkid-devel libcap-devel redhat-rpm-config rpm-build xfsprogs-devel"
+    basic_packages = "centos-release-gluster yum-utils centos-release-ceph-tentacle epel-release"
+    build_requires_common = "git bison cmake dbus-devel flex gcc-c++ krb5-devel libacl-devel libblkid-devel libcap-devel redhat-rpm-config rpm-build xfsprogs-devel openssl-devel"
     build_requires_extra_common = "libnsl2-devel libnfsidmap-devel libwbclient-devel userspace-rcu-devel"
     build_requires_extra_cephfs_vfs_rgw = "libcephfs-devel"
 
@@ -57,13 +57,13 @@ def setup_install_client_deps_cthon_pynfs(session):
 
 def setup_server_node_pynfs_cthon(session):    
     logger.info("Installing dependencies on remote node for PyNFS & Cthon")
-    _, code = run_cmd(session, "dnf -y install centos-release-ceph epel-release dnf-plugins-core")
+    _, code = run_cmd(session, "dnf -y install centos-release-ceph-tentacle epel-release dnf-plugins-core")
     assert code == 0, f"Failed to install dependencies for PyNFS & Cthon"
 
     duffy_session = DuffySession()
     version = duffy_session.centos_version
 
-    build_requires_cthon = "git bison cmake dbus-devel flex gcc-c++ krb5-devel libacl-devel libblkid-devel libcap-devel redhat-rpm-config rpm-build xfsprogs-devel lvm2 podman chrony"
+    build_requires_cthon = "git bison cmake dbus-devel flex gcc-c++ krb5-devel libacl-devel libblkid-devel libcap-devel redhat-rpm-config rpm-build xfsprogs-devel openssl-devel lvm2 podman chrony"
     build_requires_extra_cthon = "libnsl2-devel libnfsidmap-devel libwbclient-devel userspace-rcu-devel libcephfs-devel lua-devel"
 
     if version.startswith("9"):

--- a/ci_utils/nfs_ganesha/gpfs_ganesha_setup.py
+++ b/ci_utils/nfs_ganesha/gpfs_ganesha_setup.py
@@ -42,7 +42,7 @@ class GPFSGaneshaManager:
     # -------------------------------
     def intall_pre_reqs_on_vm(self):
         logger.info("[STEP]: Installing pre-requisite packages for GPFS and Ganesha on the VM")
-        run_cmd(self.session, "dnf install -y rpcbind yum-utils centos-release-ceph epel-release unzip --skip-broken")
+        run_cmd(self.session, "dnf install -y rpcbind yum-utils centos-release-ceph-tentacle epel-release unzip --skip-broken")
         run_cmd(self.session, "systemctl start rpcbind")
         run_cmd(self.session, " sudo setenforce 0")
         run_cmd(self.session, "sudo systemctl stop firewalld", check=False)
@@ -73,7 +73,7 @@ class GPFSGaneshaManager:
     def _build_from_source(self, test_workspace: str):
         logger.info("[STEP]: Building Ganesha from source...")
 
-        BASE_PACKAGES="git bison flex cmake gcc-c++ libacl-devel krb5-devel dbus-devel rpm-build redhat-rpm-config gdb"
+        BASE_PACKAGES="git bison flex cmake gcc-c++ libacl-devel krb5-devel dbus-devel rpm-build redhat-rpm-config gdb openssl-devel"
         BUILDREQUIRES_EXTRA="libnsl2-devel libnfsidmap-devel libwbclient-devel userspace-rcu-devel libcephfs-devel python3-devel"
         ADDITIONAL_PACKAGES=""
     

--- a/ci_utils/report_generation/weekly_report.py
+++ b/ci_utils/report_generation/weekly_report.py
@@ -7,7 +7,7 @@ logger = get_logger(__name__)
 
 
 def get_status(tc):
-    if tc.find("failure") is not None:
+    if tc.find("failure") is not None or tc.find("error") is not None:
         return "FAILED", "red", "#ffcccc"
     if tc.find("skipped") is not None:
         return "SKIPPED", "orange", "#ffe6cc"

--- a/tests/test_ci_pre_req.py
+++ b/tests/test_ci_pre_req.py
@@ -90,15 +90,15 @@ def test_install_dependencies_for_checkpatch_fsal(all_nodes):
     assert code == 0, f"Failed to install dependencies for checkpatch and Clang"
 
     logger.info("Installing dependencies on remote node for FSAL: %s", server_node)
-    _, code = run_cmd(session, "dnf -y install centos-release-ceph epel-release yum-utils")
+    _, code = run_cmd(session, "dnf -y install centos-release-ceph-tentacle epel-release yum-utils")
     assert code == 0, f"Failed to install dependencies for FSAL"
 
     duffy_session = DuffySession()
     version = duffy_session.centos_version
 
-    basic_packages = "yum-utils centos-release-ceph epel-release"
+    basic_packages = "yum-utils centos-release-ceph-tentacle epel-release"
 
-    build_requires_common = "git bison cmake dbus-devel flex gcc-c++ krb5-devel libacl-devel libblkid-devel libcap-devel redhat-rpm-config rpm-build xfsprogs-devel"
+    build_requires_common = "git bison cmake dbus-devel flex gcc-c++ krb5-devel libacl-devel libblkid-devel libcap-devel redhat-rpm-config rpm-build xfsprogs-devel openssl-devel"
     build_requires_gpfs_vfs = ""
 
     build_requires_extra_common = "libnsl2-devel libnfsidmap-devel libwbclient-devel userspace-rcu-devel"
@@ -137,13 +137,13 @@ def setup_node_pynfs_cthon(server_node):
     session = RemoteSession(node_ip=server_node, user="root")
     
     logger.info("Installing dependencies on remote node for PyNFS & Cthon: %s", server_node)
-    _, code = run_cmd(session, "dnf -y install centos-release-ceph epel-release dnf-plugins-core")
+    _, code = run_cmd(session, "dnf -y install centos-release-ceph-tentacle epel-release dnf-plugins-core")
     assert code == 0, f"Failed to install dependencies for PyNFS & Cthon"
 
     duffy_session = DuffySession()
     version = duffy_session.centos_version
 
-    build_requires_cthon = "git bison cmake dbus-devel flex gcc-c++ krb5-devel libacl-devel libblkid-devel libcap-devel redhat-rpm-config rpm-build xfsprogs-devel lvm2"
+    build_requires_cthon = "git bison cmake dbus-devel flex gcc-c++ krb5-devel libacl-devel libblkid-devel libcap-devel redhat-rpm-config rpm-build xfsprogs-devel openssl-devel lvm2"
     build_requires_extra_cthon = "libnsl2-devel libnfsidmap-devel libwbclient-devel userspace-rcu-devel libcephfs-devel lua-devel"
     build_requires_extra_centos10 = "python3-build python3-wheel"
 
@@ -164,7 +164,7 @@ def setup_node_vfs(server_node):
     session = RemoteSession(node_ip=server_node, user="root")
     
     logger.info("Installing dependencies on remote node for VFS %s", server_node)
-    run_cmd(session, "dnf -y install yum-utils centos-release-ceph epel-release rpcbind")
+    run_cmd(session, "dnf -y install yum-utils centos-release-ceph-tentacle epel-release rpcbind")
 
 
     logger.info("Starting rpcbind service on remote node for VFS %s", server_node)
@@ -177,7 +177,7 @@ def setup_node_vfs(server_node):
     duffy_session = DuffySession() 
     version = duffy_session.centos_version
 
-    build_requires_vfs = "git bison flex cmake gcc-c++ libacl-devel krb5-devel dbus-devel rpm-build redhat-rpm-config gdb libblkid-devel libcap-devel xfsprogs-devel"
+    build_requires_vfs = "git bison flex cmake gcc-c++ libacl-devel krb5-devel dbus-devel rpm-build redhat-rpm-config gdb libblkid-devel libcap-devel xfsprogs-devel openssl-devel"
     build_requires_extra_vfs= "libnsl2-devel libnfsidmap-devel libwbclient-devel userspace-rcu-devel libcephfs-devel python3-devel"
     build_requires_add_on_vfs = "selinux-policy-devel sqlite"
     build_requires_extra_centos10 = "python3-build python3-wheel"


### PR DESCRIPTION
To pin the ceph version to tentacle as latest(umbrella) has issues - IBMCEPH-17415
Pass Log - https://jenkins-nfs-ganesha.apps.ocp.cloud.ci.centos.org/job/gatecheck-trigger-gerrithub/1768/